### PR TITLE
Add Wizer option to rename functions.

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -87,3 +87,44 @@ fn rust_regex() -> anyhow::Result<()> {
         &include_bytes!("./regex_test.wasm")[..],
     )
 }
+
+#[test]
+fn rename_functions() -> anyhow::Result<()> {
+    let wat = r#"
+(module
+ (func (export "wizer.initialize"))
+ (func (export "func_a") (result i32)
+  i32.const 1)
+ (func (export "func_b") (result i32)
+  i32.const 2)
+ (func (export "func_c") (result i32)
+  i32.const 3))
+  "#;
+
+    let wasm = wat_to_wasm(wat)?;
+    let mut wizer = Wizer::new();
+    wizer.allow_wasi(true);
+    wizer.func_renames("func_a=func_b,func_b=func_c");
+    let wasm = wizer.run(&wasm)?;
+
+    let expected_wat = r#"
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (result i32)))
+  (func (;0;) (type 0))
+  (func (;1;) (type 1) (result i32)
+    i32.const 1)
+  (func (;2;) (type 1) (result i32)
+    i32.const 2)
+  (func (;3;) (type 1) (result i32)
+    i32.const 3)
+  (export "func_a" (func 2))
+  (export "func_b" (func 3)))
+  "#;
+
+    let expected_wasm = wat_to_wasm(expected_wat)?;
+
+    assert_eq!(expected_wasm, wasm);
+
+    Ok(())
+}


### PR DESCRIPTION
When initializing a module, it is sometimes useful to rename a function
after the module has been modified. For example, we may wish to
substitute an alternate entry point (for WASI, this is `_start()`)
since we have already performed some initialization that the normal
entry point would do.

This PR adds a `-r` option to allow such renaming. For example,

    $ wizer -r _start=my_new_start -o out.wasm in.wasm

will rename the `my_new_start` export in `in.wasm` to `_start` in
`out.wasm`, replacing the old `_start` export. Multiple renamings are
supported at once.

A followup PR will add a simple C++ example that shows how this can be
used to run C++ static constructors and other program initialization
with Wizer, and then invoke `main()` without re-running these
constructors.