### PR TITLE
Reload environment variables when an initialized module is started.

### DIFF
--- a/include/wizer.h
+++ b/include/wizer.h
@@ -9,10 +9,20 @@
 #ifndef _WIZER_H_
 #define _WIZER_H_
 
+#ifdef __wasi__
+#include <wasi/libc-environ.h>
+#endif
+
 #ifdef __cplusplus
 #define __WIZER_EXTERN_C extern "C"
 #else
 #define __WIZER_EXTERN_C extern
+#endif
+
+#ifdef __wasi__
+#define WIZER_RELOAD_ENV_VARS() __wasilibc_initialize_environ()
+#else
+#define WIZER_RELOAD_ENV_VARS()
 #endif
 
 /*
@@ -80,6 +90,11 @@
     /* This function replaces `_start` (the WASI-specified entry point) in  */ \
     /* the pre-initialized Wasm module.                                     */ \
     __attribute__((export_name("wizer.resume"))) void __wizer_resume() {       \
+        /* Call `__wasilibc_initialize_environ()` to reload environment     */ \
+        /* variables from the WASI environment. wasi-libc otherwise caches  */ \
+        /* them and may have cached environment variables present during    */ \
+        /* initialization. */                                                  \
+        WIZER_RELOAD_ENV_VARS();                                               \
         /* `__original_main()` is defined by the WASI SDK toolchain due to  */ \
         /* special semantics in C/C++ for the `main()` function, i.e., ito  */ \
         /* can either take argc/argv or not. It collects arguments using    */ \


### PR DESCRIPTION
wasi-libc caches environment variable state on the first call to
`getenv()`. Some applications using Wizer may invoke `getenv()` during
initialization, but still wish to access the current environment
variables (not their values at pre-initialization) during runtime.
Fortunately, wasi-libc provides an API for this: invoking
`__wasilibc_initialize_environ()` clears its cached state and allows it
to fetch the environment anew the next time `getenv()` is called.
This is likely less surprising than the alternative (environment
variables captured during pre-init) because calls to `getenv()` may be
buried in unsuspecting places, e.g. inside of libraries that take
logging settings from the environment.

cc @tschneidereit 