### PR TITLE
Add module linking support to Wizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,9 +1716,9 @@ checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "wasmparser"
-version = "0.78.0"
+version = "0.78.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7a8b20306d43c09c2c34e0ef68bf2959a11b01a5cae35e4c5dc1e7145547b6"
+checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmprinter"
@@ -1727,7 +1727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ccec894c70710c2e4669320a532cb2b9cfb97adb0429745642f8ce76916ed85"
 dependencies = [
  "anyhow",
- "wasmparser 0.78.0",
+ "wasmparser 0.78.2",
 ]
 
 [[package]]
@@ -2130,7 +2130,7 @@ dependencies = [
  "structopt",
  "wasi-cap-std-sync",
  "wasm-encoder",
- "wasmparser 0.78.0",
+ "wasmparser 0.78.2",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
+name = "arbitrary"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "698b65a961a9d730fb45b6b0327e20207810c9f61ee421b082b27ba003f49e2b"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +477,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df89dd0d075dea5cc5fdd6d5df6b8a61172a710b3efac1d6bdb9dd8b78f82c1a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +778,16 @@ name = "libc"
 version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86c975d637bc2a2f99440932b731491fc34c7f785d239e38af3addd3c2fd0e46"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1667,6 +1697,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-smith"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a982408719f704307ac7f45247350f06ce739d759362ef8293ed7b4d922adee8"
+dependencies = [
+ "arbitrary",
+ "indexmap",
+ "leb128",
+ "wasm-encoder",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2135,19 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wat",
+]
+
+[[package]]
+name = "wizer-fuzz"
+version = "0.0.0"
+dependencies = [
+ "env_logger 0.8.3",
+ "libfuzzer-sys",
+ "log",
+ "wasm-smith",
+ "wasmprinter",
+ "wasmtime",
+ "wizer",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0418058b38db7efc6021c5ce012e3a39c57e1a4d7bf2ddcd3789771de505d2f"
 dependencies = [
- "rand 0.8.3",
+ "rand",
 ]
 
 [[package]]
@@ -261,18 +261,18 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841476ab6d3530136b5162b64a2c6969d68141843ad2fd59126e5ea84fd9b5fe"
+checksum = "07f641ec9146b7d7498d78cd832007d66ca44a9b61f23474d1fb78e5a3701e99"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5619cef8d19530298301f91e9a0390d369260799a3d8dd01e28fc88e53637a"
+checksum = "fd1f2c0cd4ac12c954116ab2e26e40df0d51db322a855b5664fa208bc32d6686"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a319709b8267939155924114ea83f2a5b5af65ece3ac6f703d4735f3c66bb0d"
+checksum = "105e11b2f0ff7ac81f80dd05ec938ce529a75e36f3d598360d806bb5bfa75e5a"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -300,27 +300,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15925b23cd3a448443f289d85a8f53f3cf7a80f0137aa53c8e3b01ae8aefaef7"
+checksum = "51e5eba2c1858d50abf023be4d88bd0450cb12d4ec2ba3ffac56353e6d09caf2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610cf464396c89af0f9f7c64b5aa90aa9e8812ac84084098f1565b40051bc415"
+checksum = "79fa6fdd77a8d317763cd21668d3e72b96e09ac8a974326c6149f7de5aafa8ed"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d20c8bd4a1c41ded051734f0e33ad1d843a0adc98b9bd975ee6657e2c70cdc9"
+checksum = "ae11da9ca99f987c29e3eb39ebe10e9b879ecca30f3aeaee13db5e8e02b80fb6"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304e100df41f34a5a15291b37bfe0fd7abd0427a2c84195cc69578b4137f9099"
+checksum = "100ca4810058e23a5c4dcaedfa25289d1853f4a899d0960265aa7c54a4789351"
 dependencies = [
  "cranelift-codegen",
  "target-lexicon",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.72.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd473b2917303957e0bfaea6ea9d08b8c93695bee015a611a2514ce5254abc"
+checksum = "607826643d74cf2cc36973ebffd1790a11d1781e14e3f95cf5529942b2168a67"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -352,7 +352,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "wasmparser 0.76.0",
+ "wasmparser 0.77.0",
 ]
 
 [[package]]
@@ -611,24 +611,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1006,37 +995,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1046,16 +1012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1064,16 +1021,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1082,7 +1030,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core",
 ]
 
 [[package]]
@@ -1125,7 +1073,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom",
  "redox_syscall",
 ]
 
@@ -1444,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b29e388d11a2c0605bdc806ce6ed1d623a5bdbbdd5b423053444999331184e"
+checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
 
 [[package]]
 name = "termcolor"
@@ -1612,21 +1560,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b935979b43ace1ed03b14bb90598114822583c77b7616b39f62b0a91952bdc34"
+checksum = "9b0ff7337ab1e95198840773d6fbed15efbad72727d023f2ee68f8a6836d675f"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1646,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b42cc1c6e2f8485b2a3d9f70f13d734225f99e748ef33d88f2ae78592072cc"
+checksum = "ea27f1c1d537ae46f5666cee2fab6e8e286a022a5232c4be02de62d715d2f84a"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1717,30 +1659,40 @@ checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75fa62cf1464aa6655479ae454202a159cc82b7b4d66e8f174409669c0654c5"
+checksum = "51b4949d4f2b25a4b208317dcf86aacef9e7a5884e48dfc45d4aeb91808d6f86"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.74.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a4d63608421d9a22d4bce220f2841f3b609a5aaabd3ed3aeeb5fed2702c3c78"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "wasmparser"
-version = "0.76.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755a9a4afe3f6cccbbe6d7e965eef44cf260b001f93e547eba84255c1d0187d8"
+checksum = "6c7a8b20306d43c09c2c34e0ef68bf2959a11b01a5cae35e4c5dc1e7145547b6"
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ccec894c70710c2e4669320a532cb2b9cfb97adb0429745642f8ce76916ed85"
+dependencies = [
+ "anyhow",
+ "wasmparser 0.78.0",
+]
 
 [[package]]
 name = "wasmtime"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ea2ad49bb047e10ca292f55cd67040bef14b676d07e7b04ed65fd312d52ece"
+checksum = "4da03115f8ad36e50edeb6640f4ba27ed7e9a6f05c2f98f728c762966f7054c6"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1748,15 +1700,17 @@ dependencies = [
  "cfg-if",
  "cpp_demangle",
  "indexmap",
+ "lazy_static",
  "libc",
  "log",
  "paste",
+ "psm",
  "region",
  "rustc-demangle",
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.76.0",
+ "wasmparser 0.77.0",
  "wasmtime-cache",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -1769,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9353a705eb98838d885a4d0186c087167fd5ea087ef3511bdbdf1a79420a1d2d"
+checksum = "abd77ef355ee65dc5147a9d4a3d7419b94b03068fc486dc9008fb2d947724efb"
 dependencies = [
  "anyhow",
  "base64",
@@ -1790,23 +1744,23 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e769b80abbb89255926f69ba37085f7dd6608c980134838c3c89d7bf6e776bc"
+checksum = "b73c47553954eab22f432a7a60bcd695eb46508c2088cb0aa1cfd060538db3b6"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-wasm",
- "wasmparser 0.76.0",
+ "wasmparser 0.77.0",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38501788c936a4932b0ddf61135963a4b7d1f549f63a6908ae56a1c86d74fc7b"
+checksum = "5241e603c262b2ee0dfb5b2245ad539d0a99f0589909fbffc91d2a8035f2d20a"
 dependencies = [
  "anyhow",
  "gimli",
@@ -1814,15 +1768,15 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.76.0",
+ "wasmparser 0.77.0",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae793ea1387b2fede277d209bb27285366df58f0a3ae9d59e58a7941dce60fa"
+checksum = "fb8d356abc04754f5936b9377441a4a202f6bba7ad997d2cd66acb3908bc85a3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1836,14 +1790,14 @@ dependencies = [
  "region",
  "serde",
  "thiserror",
- "wasmparser 0.76.0",
+ "wasmparser 0.77.0",
 ]
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c479ba281bc54236209f43a954fc2a874ca3e5fa90116576b1ae23782948783f"
+checksum = "8ef51f16bbe65951ac8b7780c70eec963a20d6c87c59eefc6423c0ca323a6a02"
 dependencies = [
  "cc",
  "libc",
@@ -1852,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3bd0fae8396473a68a1491559d61776127bb9bea75c9a6a6c038ae4a656eb2"
+checksum = "81b066a3290a903c5beb7d765b3e82e00cd4f8ac0475297f91330fbe8e16bb17"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1873,7 +1827,7 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.76.0",
+ "wasmparser 0.77.0",
  "wasmtime-cranelift",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -1885,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79fa098a3be8fabc50f5be60f8e47694d569afdc255de37850fc80295485012"
+checksum = "bd9d5c6c8924ea1fb2372d26c0546a8c5aab94001d5ddedaa36fd7b090c04de2"
 dependencies = [
  "anyhow",
  "more-asserts",
@@ -1899,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81e2106efeef4c01917fd16956a91d39bb78c07cf97027abdba9ca98da3f258"
+checksum = "44760e80dd5f53e9af6c976120f9f1d35908ee0c646a3144083f0a57b7123ba7"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1918,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f747c656ca4680cad7846ae91c57d03f2dd4f4170da77a700df4e21f0d805378"
+checksum = "9701c6412897ba3a10fb4e17c4ec29723ed33d6feaaaeaf59f53799107ce7351"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1930,23 +1884,25 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "mach",
  "memoffset",
  "more-asserts",
- "psm",
- "rand 0.7.3",
+ "rand",
  "region",
  "thiserror",
  "wasmtime-environ",
+ "wasmtime-fiber",
  "winapi",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ebd3cfc82606e0332437cb370a9a018e8e2e8480c1bdcc10da93620ffad9e"
+checksum = "7bfa935e8a475ca6616aecc8481dfc3dcf12ad42cdaeb30746eb4addaf0316af"
 dependencies = [
  "anyhow",
+ "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
  "wasmtime-wiggle",
@@ -1955,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa44fba6a1709e2f8d59535796e38332121ba86823ce78cc4d3c8e7b3ed531da"
+checksum = "1a1782208ad6f89e8cccb56ae9366d65d75400cc5c94ba3e54456e80f3b0bf7d"
 dependencies = [
  "wasmtime",
  "wasmtime-wiggle-macro",
@@ -1967,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle-macro"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505a6f708e4db716f6c8936cee36e7d869448b38961b1b788be0e1852da8ad9"
+checksum = "4b638b65b2daabc68d8e728d4a545ea5b2c7349e4fbf299011c7e7436c365d37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1998,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0fa059022c5dabe129f02b429d67086400deb8277f89c975555dacc1dadbcc"
+checksum = "8ec280a739b69173e0ffd12c1658507996836ba4e992ed9bc1e5385a0bd72a02"
 dependencies = [
  "wast 35.0.0",
 ]
@@ -2017,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80697b8479b8aea64dfa454d593a35d46c2530c30d3e54f1c9c3bf934b52f9b"
+checksum = "bb3b6f32e575442f4710afb1d9cb8e4ac6873017fc4e8ce24c9154b1f4df02fa"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -2031,18 +1987,18 @@ dependencies = [
 
 [[package]]
 name = "wiggle-borrow"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df677e1a757a4d3bd4b4ff632a23059cd8570dd93b73962dc96a6eb64e824228"
+checksum = "8df875ad2e22a79cf238fb56c4fcb1c9128857993d74d21a47c8bf8cd1d3968e"
 dependencies = [
  "wiggle",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a47a1cf5407c9e45c2b0144dae3780bb9812093fd59d69e517239b229173a8"
+checksum = "8fe31034c216a6f33ceea8d84bbfb9c4aa982ee94367e35468cb91b129766910"
 dependencies = [
  "anyhow",
  "heck",
@@ -2055,10 +2011,11 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f4d7ee3dac8c22934a18b52269b63e1cfe75b75575821d756f5f34a2a4ca78"
+checksum = "ab77c4b75302a25083b675e535a63e6156f12ac3c2d33c89064b6b3c8152e920"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
  "wiggle-generate",
@@ -2131,7 +2088,8 @@ dependencies = [
  "structopt",
  "wasi-cap-std-sync",
  "wasm-encoder",
- "wasmparser 0.74.0",
+ "wasmparser 0.78.0",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
  "wat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,13 @@ wasmparser = "0.78.0"
 wasmtime = "0.26.0"
 wasmtime-wasi = "0.26.0"
 
+# Enable this dependency to get messages with WAT disassemblies when certain
+# internal panics occur.
+[dependencies.wasmprinter]
+version = "0.2.26"
+optional = true
+
+
 [dev-dependencies]
 criterion = "0.3.4"
 env_logger = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ wat = "1.0.36"
 members = [
     "benches/regex-bench",
     "benches/uap-bench",
+    "fuzz",
     "tests/regex-test",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rayon = "1.5.0"
 structopt = { version = "0.3.21", optional = true }
 wasi-cap-std-sync = "0.26.0"
 wasm-encoder = "0.4.0"
-wasmparser = "0.78.0"
+wasmparser = "0.78.2"
 wasmtime = "0.26.0"
 wasmtime-wasi = "0.26.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,16 +32,17 @@ env_logger = { version = "0.8.2", optional = true }
 log = "0.4.14"
 rayon = "1.5.0"
 structopt = { version = "0.3.21", optional = true }
-wasi-cap-std-sync = "0.25.0"
+wasi-cap-std-sync = "0.26.0"
 wasm-encoder = "0.4.0"
-wasmparser = "0.74.0"
-wasmtime = "0.25.0"
-wasmtime-wasi = "0.25.0"
+wasmparser = "0.78.0"
+wasmtime = "0.26.0"
+wasmtime-wasi = "0.26.0"
 
 [dev-dependencies]
-wat = "1.0.34"
-env_logger = "0.8.2"
 criterion = "0.3.4"
+env_logger = "0.8.2"
+wasmprinter = "0.2.26"
+wat = "1.0.36"
 
 [workspace]
 members = [

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,5 @@
+test.wasm
+test.wat
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+
+[package]
+name = "wizer-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+env_logger = "0.8.3"
+libfuzzer-sys = "0.4"
+log = "0.4.14"
+wasm-smith = "0.4.0"
+wasmprinter = "0.2.26"
+wasmtime = "0.26.0"
+
+[dependencies.wizer]
+path = ".."
+
+[[bin]]
+name = "same_result"
+path = "fuzz_targets/same_result.rs"
+test = false
+doc = false

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -93,6 +93,12 @@ pub fn dummy_value(val_ty: ValType) -> Val {
     }
 }
 
+/// Construct a sequence of dummy values for the given types.
+#[cfg(fuzzing)]
+pub fn dummy_values(val_tys: impl IntoIterator<Item = ValType>) -> Vec<Val> {
+    val_tys.into_iter().map(dummy_value).collect()
+}
+
 /// Construct a dummy global for the given global type.
 pub fn dummy_global(store: &Store, ty: GlobalType) -> Global {
     let val = dummy_value(ty.content().clone());

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -1,0 +1,623 @@
+//! Dummy implementations of things that a Wasm module can import.
+//!
+//! Forked from `wasmtime/crates/fuzzing/src/oracles/dummy.rs`.
+
+use std::fmt::Write;
+use wasmtime::*;
+
+/// Create dummy imports for instantiating the module.
+pub fn dummy_imports(
+    store: &wasmtime::Store,
+    module: &wasmtime::Module,
+    linker: &mut wasmtime::Linker,
+) -> anyhow::Result<()> {
+    log::debug!("Creating dummy imports");
+
+    for imp in module.imports() {
+        match imp.name() {
+            Some(name) => {
+                if linker.get_one_by_name(imp.module(), Some(name)).is_ok() {
+                    // Already defined, must be part of WASI.
+                    continue;
+                }
+
+                linker
+                    .define(imp.module(), name, dummy_extern(store, imp.ty()))
+                    .unwrap();
+            }
+            None => match imp.ty() {
+                wasmtime::ExternType::Instance(ty) => {
+                    for ty in ty.exports() {
+                        if linker
+                            .get_one_by_name(imp.module(), Some(ty.name()))
+                            .is_ok()
+                        {
+                            // Already defined, must be part of WASI.
+                            continue;
+                        }
+
+                        linker
+                            .define(imp.module(), ty.name(), dummy_extern(store, ty.ty()))
+                            .unwrap();
+                    }
+                }
+                other => {
+                    if linker.get_one_by_name(imp.module(), None).is_ok() {
+                        // Already defined, must be part of WASI.
+                        continue;
+                    }
+
+                    linker
+                        .define_name(imp.module(), dummy_extern(store, other))
+                        .unwrap();
+                }
+            },
+        }
+    }
+
+    Ok(())
+}
+
+/// Construct a dummy `Extern` from its type signature
+pub fn dummy_extern(store: &Store, ty: ExternType) -> Extern {
+    match ty {
+        ExternType::Func(func_ty) => Extern::Func(dummy_func(store, func_ty)),
+        ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)),
+        ExternType::Table(table_ty) => Extern::Table(dummy_table(store, table_ty)),
+        ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(store, mem_ty)),
+        ExternType::Instance(instance_ty) => Extern::Instance(dummy_instance(store, instance_ty)),
+        ExternType::Module(module_ty) => Extern::Module(dummy_module(store, module_ty)),
+    }
+}
+
+/// Construct a dummy function for the given function type
+pub fn dummy_func(store: &Store, ty: FuncType) -> Func {
+    Func::new(store, ty.clone(), move |_, _, results| {
+        for (ret_ty, result) in ty.results().zip(results) {
+            *result = dummy_value(ret_ty);
+        }
+        Ok(())
+    })
+}
+
+/// Construct a dummy value for the given value type.
+pub fn dummy_value(val_ty: ValType) -> Val {
+    match val_ty {
+        ValType::I32 => Val::I32(0),
+        ValType::I64 => Val::I64(0),
+        ValType::F32 => Val::F32(0),
+        ValType::F64 => Val::F64(0),
+        ValType::V128 => Val::V128(0),
+        ValType::ExternRef => Val::ExternRef(None),
+        ValType::FuncRef => Val::FuncRef(None),
+    }
+}
+
+/// Construct a dummy global for the given global type.
+pub fn dummy_global(store: &Store, ty: GlobalType) -> Global {
+    let val = dummy_value(ty.content().clone());
+    Global::new(store, ty, val).unwrap()
+}
+
+/// Construct a dummy table for the given table type.
+pub fn dummy_table(store: &Store, ty: TableType) -> Table {
+    let init_val = dummy_value(ty.element().clone());
+    Table::new(store, ty, init_val).unwrap()
+}
+
+/// Construct a dummy memory for the given memory type.
+pub fn dummy_memory(store: &Store, ty: MemoryType) -> Memory {
+    Memory::new(store, ty)
+}
+
+/// Construct a dummy instance for the given instance type.
+///
+/// This is done by using the expected type to generate a module on-the-fly
+/// which we the instantiate.
+pub fn dummy_instance(store: &Store, ty: InstanceType) -> Instance {
+    let mut wat = WatGenerator::new();
+    for ty in ty.exports() {
+        wat.export(&ty);
+    }
+    let module = Module::new(store.engine(), &wat.finish()).unwrap();
+    Instance::new(store, &module, &[]).unwrap()
+}
+
+/// Construct a dummy module for the given module type.
+///
+/// This is done by using the expected type to generate a module on-the-fly.
+pub fn dummy_module(store: &Store, ty: ModuleType) -> Module {
+    let mut wat = WatGenerator::new();
+    for ty in ty.imports() {
+        wat.import(&ty);
+    }
+    for ty in ty.exports() {
+        wat.export(&ty);
+    }
+    Module::new(store.engine(), &wat.finish()).unwrap()
+}
+
+struct WatGenerator {
+    tmp: usize,
+    dst: String,
+}
+
+impl WatGenerator {
+    fn new() -> WatGenerator {
+        WatGenerator {
+            tmp: 0,
+            dst: String::from("(module\n"),
+        }
+    }
+
+    fn finish(mut self) -> String {
+        self.dst.push_str(")\n");
+        self.dst
+    }
+
+    fn import(&mut self, ty: &ImportType<'_>) {
+        write!(self.dst, "(import ").unwrap();
+        self.str(ty.module());
+        write!(self.dst, " ").unwrap();
+        if let Some(field) = ty.name() {
+            self.str(field);
+            write!(self.dst, " ").unwrap();
+        }
+        self.item_ty(&ty.ty());
+        writeln!(self.dst, ")").unwrap();
+    }
+
+    fn item_ty(&mut self, ty: &ExternType) {
+        match ty {
+            ExternType::Memory(mem) => {
+                write!(
+                    self.dst,
+                    "(memory {} {})",
+                    mem.limits().min(),
+                    match mem.limits().max() {
+                        Some(max) => max.to_string(),
+                        None => String::new(),
+                    }
+                )
+                .unwrap();
+            }
+            ExternType::Table(table) => {
+                write!(
+                    self.dst,
+                    "(table {} {} {})",
+                    table.limits().min(),
+                    match table.limits().max() {
+                        Some(max) => max.to_string(),
+                        None => String::new(),
+                    },
+                    wat_ty(table.element()),
+                )
+                .unwrap();
+            }
+            ExternType::Global(ty) => {
+                if ty.mutability() == Mutability::Const {
+                    write!(self.dst, "(global {})", wat_ty(ty.content())).unwrap();
+                } else {
+                    write!(self.dst, "(global (mut {}))", wat_ty(ty.content())).unwrap();
+                }
+            }
+            ExternType::Func(ty) => {
+                write!(self.dst, "(func ").unwrap();
+                self.func_sig(ty);
+                write!(self.dst, ")").unwrap();
+            }
+            ExternType::Instance(ty) => {
+                writeln!(self.dst, "(instance").unwrap();
+                for ty in ty.exports() {
+                    write!(self.dst, "(export ").unwrap();
+                    self.str(ty.name());
+                    write!(self.dst, " ").unwrap();
+                    self.item_ty(&ty.ty());
+                    writeln!(self.dst, ")").unwrap();
+                }
+                write!(self.dst, ")").unwrap();
+            }
+            ExternType::Module(ty) => {
+                writeln!(self.dst, "(module").unwrap();
+                for ty in ty.imports() {
+                    self.import(&ty);
+                    writeln!(self.dst, "").unwrap();
+                }
+                for ty in ty.exports() {
+                    write!(self.dst, "(export ").unwrap();
+                    self.str(ty.name());
+                    write!(self.dst, " ").unwrap();
+                    self.item_ty(&ty.ty());
+                    writeln!(self.dst, ")").unwrap();
+                }
+                write!(self.dst, ")").unwrap();
+            }
+        }
+    }
+
+    fn export(&mut self, ty: &ExportType<'_>) {
+        let wat_name = format!("item{}", self.tmp);
+        self.tmp += 1;
+        let item_ty = ty.ty();
+        self.item(&wat_name, &item_ty);
+
+        write!(self.dst, "(export ").unwrap();
+        self.str(ty.name());
+        write!(self.dst, " (").unwrap();
+        match item_ty {
+            ExternType::Memory(_) => write!(self.dst, "memory").unwrap(),
+            ExternType::Global(_) => write!(self.dst, "global").unwrap(),
+            ExternType::Func(_) => write!(self.dst, "func").unwrap(),
+            ExternType::Instance(_) => write!(self.dst, "instance").unwrap(),
+            ExternType::Table(_) => write!(self.dst, "table").unwrap(),
+            ExternType::Module(_) => write!(self.dst, "module").unwrap(),
+        }
+        writeln!(self.dst, " ${}))", wat_name).unwrap();
+    }
+
+    fn item(&mut self, name: &str, ty: &ExternType) {
+        match ty {
+            ExternType::Memory(mem) => {
+                write!(
+                    self.dst,
+                    "(memory ${} {} {})\n",
+                    name,
+                    mem.limits().min(),
+                    match mem.limits().max() {
+                        Some(max) => max.to_string(),
+                        None => String::new(),
+                    }
+                )
+                .unwrap();
+            }
+            ExternType::Table(table) => {
+                write!(
+                    self.dst,
+                    "(table ${} {} {} {})\n",
+                    name,
+                    table.limits().min(),
+                    match table.limits().max() {
+                        Some(max) => max.to_string(),
+                        None => String::new(),
+                    },
+                    wat_ty(table.element()),
+                )
+                .unwrap();
+            }
+            ExternType::Global(ty) => {
+                write!(self.dst, "(global ${} ", name).unwrap();
+                if ty.mutability() == Mutability::Var {
+                    write!(self.dst, "(mut ").unwrap();
+                }
+                write!(self.dst, "{}", wat_ty(ty.content())).unwrap();
+                if ty.mutability() == Mutability::Var {
+                    write!(self.dst, ")").unwrap();
+                }
+                write!(self.dst, " (").unwrap();
+                self.value(ty.content());
+                writeln!(self.dst, "))").unwrap();
+            }
+            ExternType::Func(ty) => {
+                write!(self.dst, "(func ${} ", name).unwrap();
+                self.func_sig(ty);
+                for ty in ty.results() {
+                    writeln!(self.dst, "").unwrap();
+                    self.value(&ty);
+                }
+                writeln!(self.dst, ")").unwrap();
+            }
+            ExternType::Module(ty) => {
+                writeln!(self.dst, "(module ${}", name).unwrap();
+                for ty in ty.imports() {
+                    self.import(&ty);
+                }
+                for ty in ty.exports() {
+                    self.export(&ty);
+                }
+                self.dst.push_str(")\n");
+            }
+            ExternType::Instance(ty) => {
+                writeln!(self.dst, "(module ${}_module", name).unwrap();
+                for ty in ty.exports() {
+                    self.export(&ty);
+                }
+                self.dst.push_str(")\n");
+                writeln!(self.dst, "(instance ${} (instantiate ${0}_module))", name).unwrap();
+            }
+        }
+    }
+
+    fn func_sig(&mut self, ty: &FuncType) {
+        write!(self.dst, "(param ").unwrap();
+        for ty in ty.params() {
+            write!(self.dst, "{} ", wat_ty(&ty)).unwrap();
+        }
+        write!(self.dst, ") (result ").unwrap();
+        for ty in ty.results() {
+            write!(self.dst, "{} ", wat_ty(&ty)).unwrap();
+        }
+        write!(self.dst, ")").unwrap();
+    }
+
+    fn value(&mut self, ty: &ValType) {
+        match ty {
+            ValType::I32 => write!(self.dst, "i32.const 0").unwrap(),
+            ValType::I64 => write!(self.dst, "i64.const 0").unwrap(),
+            ValType::F32 => write!(self.dst, "f32.const 0").unwrap(),
+            ValType::F64 => write!(self.dst, "f64.const 0").unwrap(),
+            ValType::V128 => write!(self.dst, "v128.const i32x4 0 0 0 0").unwrap(),
+            ValType::ExternRef => write!(self.dst, "ref.null extern").unwrap(),
+            ValType::FuncRef => write!(self.dst, "ref.null func").unwrap(),
+        }
+    }
+
+    fn str(&mut self, name: &str) {
+        let mut bytes = [0; 4];
+        self.dst.push_str("\"");
+        for c in name.chars() {
+            let v = c as u32;
+            if v >= 0x20 && v < 0x7f && c != '"' && c != '\\' && v < 0xff {
+                self.dst.push(c);
+            } else {
+                for byte in c.encode_utf8(&mut bytes).as_bytes() {
+                    self.hex_byte(*byte);
+                }
+            }
+        }
+        self.dst.push_str("\"");
+    }
+
+    fn hex_byte(&mut self, byte: u8) {
+        fn to_hex(b: u8) -> char {
+            if b < 10 {
+                (b'0' + b) as char
+            } else {
+                (b'a' + b - 10) as char
+            }
+        }
+        self.dst.push('\\');
+        self.dst.push(to_hex((byte >> 4) & 0xf));
+        self.dst.push(to_hex(byte & 0xf));
+    }
+}
+
+fn wat_ty(ty: &ValType) -> &'static str {
+    match ty {
+        ValType::I32 => "i32",
+        ValType::I64 => "i64",
+        ValType::F32 => "f32",
+        ValType::F64 => "f64",
+        ValType::V128 => "v128",
+        ValType::ExternRef => "externref",
+        ValType::FuncRef => "funcref",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn store() -> Store {
+        let mut config = Config::default();
+        config.wasm_module_linking(true);
+        config.wasm_multi_memory(true);
+        let engine = wasmtime::Engine::new(&config).unwrap();
+        Store::new(&engine)
+    }
+
+    #[test]
+    fn dummy_table_import() {
+        let store = store();
+        let table = dummy_table(
+            &store,
+            TableType::new(ValType::ExternRef, Limits::at_least(10)),
+        );
+        assert_eq!(table.size(), 10);
+        for i in 0..10 {
+            assert!(table.get(i).unwrap().unwrap_externref().is_none());
+        }
+    }
+
+    #[test]
+    fn dummy_global_import() {
+        let store = store();
+        let global = dummy_global(&store, GlobalType::new(ValType::I32, Mutability::Const));
+        assert_eq!(global.val_type(), ValType::I32);
+        assert_eq!(global.mutability(), Mutability::Const);
+    }
+
+    #[test]
+    fn dummy_memory_import() {
+        let store = store();
+        let memory = dummy_memory(&store, MemoryType::new(Limits::at_least(1)));
+        assert_eq!(memory.size(), 1);
+    }
+
+    #[test]
+    fn dummy_function_import() {
+        let store = store();
+        let func_ty = FuncType::new(vec![ValType::I32], vec![ValType::I64]);
+        let func = dummy_func(&store, func_ty.clone());
+        assert_eq!(func.ty(), func_ty);
+    }
+
+    #[test]
+    fn dummy_instance_import() {
+        let store = store();
+
+        let mut instance_ty = InstanceType::new();
+
+        // Functions.
+        instance_ty.add_named_export("func0", FuncType::new(vec![ValType::I32], vec![]).into());
+        instance_ty.add_named_export("func1", FuncType::new(vec![], vec![ValType::I64]).into());
+
+        // Globals.
+        instance_ty.add_named_export(
+            "global0",
+            GlobalType::new(ValType::I32, Mutability::Const).into(),
+        );
+        instance_ty.add_named_export(
+            "global1",
+            GlobalType::new(ValType::I64, Mutability::Var).into(),
+        );
+
+        // Tables.
+        instance_ty.add_named_export(
+            "table0",
+            TableType::new(ValType::ExternRef, Limits::at_least(1)).into(),
+        );
+        instance_ty.add_named_export(
+            "table1",
+            TableType::new(ValType::ExternRef, Limits::at_least(1)).into(),
+        );
+
+        // Memories.
+        instance_ty.add_named_export("memory0", MemoryType::new(Limits::at_least(1)).into());
+        instance_ty.add_named_export("memory1", MemoryType::new(Limits::at_least(1)).into());
+
+        // Modules.
+        instance_ty.add_named_export("module0", ModuleType::new().into());
+        instance_ty.add_named_export("module1", ModuleType::new().into());
+
+        // Instances.
+        instance_ty.add_named_export("instance0", InstanceType::new().into());
+        instance_ty.add_named_export("instance1", InstanceType::new().into());
+
+        let instance = dummy_instance(&store, instance_ty.clone());
+
+        let mut expected_exports = vec![
+            "func0",
+            "func1",
+            "global0",
+            "global1",
+            "table0",
+            "table1",
+            "memory0",
+            "memory1",
+            "module0",
+            "module1",
+            "instance0",
+            "instance1",
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
+        for exp in instance.ty().exports() {
+            let was_expected = expected_exports.remove(exp.name());
+            assert!(was_expected);
+        }
+        assert!(expected_exports.is_empty());
+    }
+
+    #[test]
+    fn dummy_module_import() {
+        let store = store();
+
+        let mut module_ty = ModuleType::new();
+
+        // Multiple exported and imported functions.
+        module_ty.add_named_export("func0", FuncType::new(vec![ValType::I32], vec![]).into());
+        module_ty.add_named_export("func1", FuncType::new(vec![], vec![ValType::I64]).into());
+        module_ty.add_named_import(
+            "func2",
+            None,
+            FuncType::new(vec![ValType::I64], vec![]).into(),
+        );
+        module_ty.add_named_import(
+            "func3",
+            None,
+            FuncType::new(vec![], vec![ValType::I32]).into(),
+        );
+
+        // Multiple exported and imported globals.
+        module_ty.add_named_export(
+            "global0",
+            GlobalType::new(ValType::I32, Mutability::Const).into(),
+        );
+        module_ty.add_named_export(
+            "global1",
+            GlobalType::new(ValType::I64, Mutability::Var).into(),
+        );
+        module_ty.add_named_import(
+            "global2",
+            None,
+            GlobalType::new(ValType::I32, Mutability::Var).into(),
+        );
+        module_ty.add_named_import(
+            "global3",
+            None,
+            GlobalType::new(ValType::I64, Mutability::Const).into(),
+        );
+
+        // Multiple exported and imported tables.
+        module_ty.add_named_export(
+            "table0",
+            TableType::new(ValType::ExternRef, Limits::at_least(1)).into(),
+        );
+        module_ty.add_named_export(
+            "table1",
+            TableType::new(ValType::ExternRef, Limits::at_least(1)).into(),
+        );
+        module_ty.add_named_import(
+            "table2",
+            None,
+            TableType::new(ValType::ExternRef, Limits::at_least(1)).into(),
+        );
+        module_ty.add_named_import(
+            "table3",
+            None,
+            TableType::new(ValType::ExternRef, Limits::at_least(1)).into(),
+        );
+
+        // Multiple exported and imported memories.
+        module_ty.add_named_export("memory0", MemoryType::new(Limits::at_least(1)).into());
+        module_ty.add_named_export("memory1", MemoryType::new(Limits::at_least(1)).into());
+        module_ty.add_named_import("memory2", None, MemoryType::new(Limits::at_least(1)).into());
+        module_ty.add_named_import("memory3", None, MemoryType::new(Limits::at_least(1)).into());
+
+        // An exported and an imported module.
+        module_ty.add_named_export("module0", ModuleType::new().into());
+        module_ty.add_named_import("module1", None, ModuleType::new().into());
+
+        // An exported and an imported instance.
+        module_ty.add_named_export("instance0", InstanceType::new().into());
+        module_ty.add_named_import("instance1", None, InstanceType::new().into());
+
+        // Create the module.
+        let module = dummy_module(&store, module_ty);
+
+        // Check that we have the expected exports.
+        assert!(module.get_export("func0").is_some());
+        assert!(module.get_export("func1").is_some());
+        assert!(module.get_export("global0").is_some());
+        assert!(module.get_export("global1").is_some());
+        assert!(module.get_export("table0").is_some());
+        assert!(module.get_export("table1").is_some());
+        assert!(module.get_export("memory0").is_some());
+        assert!(module.get_export("memory1").is_some());
+        assert!(module.get_export("instance0").is_some());
+        assert!(module.get_export("module0").is_some());
+
+        // Check that we have the exported imports.
+        let mut expected_imports = vec![
+            "func2",
+            "func3",
+            "global2",
+            "global3",
+            "table2",
+            "table3",
+            "memory2",
+            "memory3",
+            "instance1",
+            "module1",
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
+        for imp in module.imports() {
+            assert!(imp.name().is_none());
+            let was_expected = expected_imports.remove(imp.module());
+            assert!(was_expected);
+        }
+        assert!(expected_imports.is_empty());
+    }
+}

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,0 +1,333 @@
+use wasm_encoder::SectionId;
+
+use crate::translate;
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+
+/// Info that we keep track of on a per module-within-a-module-linking-bundle
+/// basis.
+///
+/// These are created during during our `parse` pass and then used throughout
+/// our later passes.
+#[derive(Clone)]
+pub(crate) struct ModuleInfo<'a> {
+    /// This module's id (i.e. its pre-order traversal index).
+    pub id: u32,
+
+    /// The raw sections from the original Wasm input.
+    pub raw_sections: Vec<wasm_encoder::RawSection<'a>>,
+
+    /// This vector has `n` entries when the module has `n` import sections. The
+    /// `i`th entry is a count of how many instance imports are in the `i`th
+    /// import section.
+    pub instance_import_counts: Vec<u32>,
+
+    /// Types available in this module.
+    ///
+    /// We keep track of these for determining how many things we need to
+    /// re-export for new instantiations and for inner module's aliases.
+    pub types: Vec<wasmparser::TypeDef<'a>>,
+
+    /// Imports made by this module.
+    pub imports: Vec<wasmparser::Import<'a>>,
+
+    /// Aliases that this module defines.
+    pub aliases: Vec<wasmparser::Alias<'a>>,
+
+    /// How many more not-yet-parsed child modules are expected for this module?
+    ///
+    /// This is only used during parsing.
+    pub child_modules_expected: u32,
+
+    /// Directly nested inner modules of this module.
+    ///
+    /// These entries are populated as we finish instrumenting the inner
+    /// modules.
+    pub modules: Vec<ModuleInfo<'a>>,
+
+    /// A map from instance indices to each instance's type for all defined,
+    /// imported, and aliased instances.
+    pub instances: Vec<wasmparser::InstanceType<'a>>,
+
+    /// A map from indices of defined instantiations (as opposed to imported or
+    /// aliased instantiations) to the id of the module that was instantiated
+    /// and the import arguments.
+    pub instantiations: BTreeMap<u32, (u32, Vec<wasmparser::InstanceArg<'a>>)>,
+
+    /// A map from global indices to each global's type for all defined,
+    /// imported, and aliased globals.
+    pub globals: Vec<wasmparser::GlobalType>,
+
+    /// The index within the global index space where defined globals (as
+    /// opposed to imported or aliased) begin.
+    ///
+    /// If this is `None`, then there are no locally defined globals.
+    pub defined_globals_index: Option<u32>,
+
+    /// This module's exports.
+    ///
+    /// This is used later on, in the rewrite phase, when we are inserting state
+    /// instance imports.
+    ///
+    /// Note that this does *not* include the `__wizer_thing_N` exports that
+    /// this instrumentation pass adds.
+    pub exports: Vec<wasmparser::Export<'a>>,
+
+    /// A currently-being-encoded module section.
+    ///
+    /// As we finish instrumenting child modules, we add them here. If we aren't
+    /// currently processing this module's children, then this is `None`.
+    pub module_section: Option<wasm_encoder::ModuleSection>,
+
+    /// Maps from function index to the function's type index for all functions
+    /// defined, imported, and aliased in this module.
+    pub functions: Vec<u32>,
+
+    /// Maps from table index to the table's type for all tables defined,
+    /// imported, and aliased in this module.
+    pub tables: Vec<wasmparser::TableType>,
+
+    /// Maps from memory index to the memory's type for all memories defined,
+    /// imported, and aliased in this module.
+    pub memories: Vec<wasmparser::MemoryType>,
+
+    /// The index within the memory index space where defined memories (as
+    /// opposed to imported or aliased) begin.
+    ///
+    /// If this is `None`, then there are no locally defined memories.
+    pub defined_memories_index: Option<u32>,
+}
+
+impl<'a> ModuleInfo<'a> {
+    /// Create the `ModuleInfo` for the root of a module-linking bundle.
+    pub fn for_root() -> Self {
+        Self {
+            id: 0,
+            raw_sections: vec![],
+            instance_import_counts: vec![],
+            modules: vec![],
+            types: vec![],
+            imports: vec![],
+            aliases: vec![],
+            globals: vec![],
+            defined_globals_index: None,
+            instances: vec![],
+            instantiations: BTreeMap::new(),
+            child_modules_expected: 0,
+            module_section: None,
+            exports: vec![],
+            functions: vec![],
+            tables: vec![],
+            memories: vec![],
+            defined_memories_index: None,
+        }
+    }
+
+    /// Create a new `ModuleInfo` for an inner module.
+    pub fn for_inner(id: u32) -> Self {
+        Self {
+            id,
+            raw_sections: vec![],
+            instance_import_counts: vec![],
+            modules: vec![],
+            types: vec![],
+            imports: vec![],
+            aliases: vec![],
+            globals: vec![],
+            defined_globals_index: None,
+            instances: vec![],
+            instantiations: BTreeMap::new(),
+            child_modules_expected: 0,
+            module_section: None,
+            exports: vec![],
+            functions: vec![],
+            tables: vec![],
+            memories: vec![],
+            defined_memories_index: None,
+        }
+    }
+
+    /// Add a new raw section to this module info during parsing.
+    pub fn add_raw_section(
+        &mut self,
+        id: SectionId,
+        range: wasmparser::Range,
+        full_wasm: &'a [u8],
+    ) {
+        self.raw_sections.push(wasm_encoder::RawSection {
+            id: id as u8,
+            data: &full_wasm[range.start..range.end],
+        })
+    }
+
+    /// Is this the root of the module linking bundle?
+    pub fn is_root(&self) -> bool {
+        self.id == 0
+    }
+
+    /// Define an instance type for this module's exports.
+    ///
+    /// Returns the index of the type and updates the total count of types in
+    /// `num_types`.
+    pub fn define_instance_type(
+        &self,
+        num_types: &mut u32,
+        types: &mut wasm_encoder::TypeSection,
+    ) -> u32 {
+        let ty_index = *num_types;
+        types.instance(self.exports.iter().map(|e| {
+            let name = e.field;
+            let index = usize::try_from(e.index).unwrap();
+            let item = match e.kind {
+                wasmparser::ExternalKind::Function => {
+                    let func_ty = self.functions[index];
+                    wasm_encoder::EntityType::Function(func_ty)
+                }
+                wasmparser::ExternalKind::Table => {
+                    let ty = self.tables[index];
+                    wasm_encoder::EntityType::Table(translate::table_type(ty))
+                }
+                wasmparser::ExternalKind::Memory => {
+                    let ty = self.memories[index];
+                    wasm_encoder::EntityType::Memory(translate::memory_type(ty))
+                }
+                wasmparser::ExternalKind::Global => {
+                    let ty = self.globals[index];
+                    wasm_encoder::EntityType::Global(translate::global_type(ty))
+                }
+                wasmparser::ExternalKind::Instance => wasm_encoder::EntityType::Instance(e.index),
+                wasmparser::ExternalKind::Module
+                | wasmparser::ExternalKind::Type
+                | wasmparser::ExternalKind::Event => unreachable!(),
+            };
+            (name, item)
+        }));
+        *num_types += 1;
+        ty_index
+    }
+
+    /// Construct an instance type for instances of this module.
+    pub fn instance_type(&self) -> wasmparser::InstanceType<'a> {
+        wasmparser::InstanceType {
+            exports: self
+                .exports
+                .iter()
+                .map(|e| {
+                    let index = usize::try_from(e.index).unwrap();
+                    wasmparser::ExportType {
+                        name: e.field,
+                        ty: match e.kind {
+                            wasmparser::ExternalKind::Function => {
+                                let func_ty = self.functions[index];
+                                wasmparser::ImportSectionEntryType::Function(func_ty)
+                            }
+                            wasmparser::ExternalKind::Table => {
+                                let ty = self.tables[index];
+                                wasmparser::ImportSectionEntryType::Table(ty)
+                            }
+                            wasmparser::ExternalKind::Memory => {
+                                let ty = self.memories[index];
+                                wasmparser::ImportSectionEntryType::Memory(ty)
+                            }
+                            wasmparser::ExternalKind::Global => {
+                                let ty = self.globals[index];
+                                wasmparser::ImportSectionEntryType::Global(ty)
+                            }
+                            wasmparser::ExternalKind::Instance => {
+                                wasmparser::ImportSectionEntryType::Instance(e.index)
+                            }
+                            wasmparser::ExternalKind::Module
+                            | wasmparser::ExternalKind::Type
+                            | wasmparser::ExternalKind::Event => unreachable!(),
+                        },
+                    }
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        }
+    }
+
+    /// Get an export from the `n`th instance by name.
+    pub fn instance_export(
+        &self,
+        instance: u32,
+        name: &str,
+    ) -> Option<wasmparser::ImportSectionEntryType> {
+        let instance = usize::try_from(instance).unwrap();
+        let instance = &self.instances[instance];
+        instance
+            .exports
+            .iter()
+            .find(|e| e.name == name)
+            .map(|e| e.ty)
+    }
+
+    /// Do a pre-order traversal over this module tree.
+    pub fn pre_order<'b, F>(&'b self, mut f: F)
+    where
+        F: FnMut(&'b ModuleInfo<'a>),
+    {
+        let mut stack = vec![self];
+        while let Some(info) = stack.pop() {
+            f(info);
+            stack.extend(info.modules.iter().rev());
+        }
+    }
+
+    /// The number of defined memories in this module.
+    pub fn defined_memories_len(&self) -> usize {
+        self.defined_memories_index.map_or(0, |n| {
+            let n = usize::try_from(n).unwrap();
+            assert!(self.memories.len() > n);
+            self.memories.len() - n
+        })
+    }
+
+    /// Iterate over the defined memories in this module.
+    pub fn defined_memories<'b>(&'b self) -> impl Iterator<Item = wasmparser::MemoryType> + 'b {
+        self.memories
+            .iter()
+            .skip(
+                self.defined_memories_index
+                    .map_or(self.memories.len(), |i| usize::try_from(i).unwrap()),
+            )
+            .copied()
+    }
+
+    /// The number of defined globals in this module.
+    pub fn defined_globals_len(&self) -> usize {
+        self.defined_globals_index.map_or(0, |n| {
+            let n = usize::try_from(n).unwrap();
+            assert!(self.globals.len() > n);
+            self.globals.len() - n
+        })
+    }
+
+    /// Iterate over the defined globals in this module.
+    pub fn defined_globals<'b>(&'b self) -> impl Iterator<Item = wasmparser::GlobalType> + 'b {
+        self.globals
+            .iter()
+            .skip(
+                self.defined_globals_index
+                    .map_or(self.globals.len(), |i| usize::try_from(i).unwrap()),
+            )
+            .copied()
+    }
+
+    /// Iterate over the initial sections in this Wasm module.
+    pub fn initial_sections<'b>(
+        &'b self,
+    ) -> impl Iterator<Item = &'b wasm_encoder::RawSection> + 'b {
+        self.raw_sections
+            .iter()
+            .filter(|s| s.id != SectionId::Custom.into())
+            .take_while(|s| match s.id {
+                x if x == SectionId::Type.into() => true,
+                x if x == SectionId::Import.into() => true,
+                x if x == SectionId::Alias.into() => true,
+                x if x == SectionId::Module.into() => true,
+                x if x == SectionId::Instance.into() => true,
+                _ => false,
+            })
+    }
+}

--- a/src/info.rs
+++ b/src/info.rs
@@ -24,6 +24,18 @@ impl<'a> ModuleContext<'a> {
         Module { id: 0 }
     }
 
+    /// Does this context represent a single Wasm module that doesn't use module
+    /// linking, or does it represent a bundle of one or more Wasm modules that
+    /// use module linking?
+    pub fn uses_module_linking(&self) -> bool {
+        self.arena.len() > 1
+            || self.root().initial_sections(self).any(|s| {
+                s.id == SectionId::Alias.into()
+                    || s.id == SectionId::Module.into()
+                    || s.id == SectionId::Instance.into()
+            })
+    }
+
     /// Get a shared reference to the `DefinedModuleInfo` for this module,
     /// following through aliases.
     fn resolve(&self, module: Module) -> &DefinedModuleInfo<'a> {

--- a/src/info.rs
+++ b/src/info.rs
@@ -207,8 +207,7 @@ impl<'a> ModuleInfo<'a> {
                         },
                     }
                 })
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
+                .collect(),
         }
     }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 ///
 /// These are created during during our `parse` pass and then used throughout
 /// our later passes.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct ModuleInfo<'a> {
     /// This module's id (i.e. its pre-order traversal index).
     pub id: u32,
@@ -101,49 +101,14 @@ pub(crate) struct ModuleInfo<'a> {
 impl<'a> ModuleInfo<'a> {
     /// Create the `ModuleInfo` for the root of a module-linking bundle.
     pub fn for_root() -> Self {
-        Self {
-            id: 0,
-            raw_sections: vec![],
-            instance_import_counts: vec![],
-            modules: vec![],
-            types: vec![],
-            imports: vec![],
-            aliases: vec![],
-            globals: vec![],
-            defined_globals_index: None,
-            instances: vec![],
-            instantiations: BTreeMap::new(),
-            child_modules_expected: 0,
-            module_section: None,
-            exports: vec![],
-            functions: vec![],
-            tables: vec![],
-            memories: vec![],
-            defined_memories_index: None,
-        }
+        Self::default()
     }
 
     /// Create a new `ModuleInfo` for an inner module.
     pub fn for_inner(id: u32) -> Self {
         Self {
             id,
-            raw_sections: vec![],
-            instance_import_counts: vec![],
-            modules: vec![],
-            types: vec![],
-            imports: vec![],
-            aliases: vec![],
-            globals: vec![],
-            defined_globals_index: None,
-            instances: vec![],
-            instantiations: BTreeMap::new(),
-            child_modules_expected: 0,
-            module_section: None,
-            exports: vec![],
-            functions: vec![],
-            tables: vec![],
-            memories: vec![],
-            defined_memories_index: None,
+            ..Self::default()
         }
     }
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -355,9 +355,11 @@ impl Module {
             wasmparser::ImportSectionEntryType::Table(ty) => {
                 self.push_table(cx, ty);
             }
-            wasmparser::ImportSectionEntryType::Module(_)
-            | wasmparser::ImportSectionEntryType::Event(_) => {
-                unreachable!()
+            wasmparser::ImportSectionEntryType::Module(_) => {
+                unreachable!("we disallow module imports; checked in validation")
+            }
+            wasmparser::ImportSectionEntryType::Event(_) => {
+                unreachable!("exceptions are unsupported; checked in validation")
             }
         }
     }

--- a/src/info.rs
+++ b/src/info.rs
@@ -223,12 +223,7 @@ impl Module {
         cx: &ModuleContext<'_>,
         ty: wasmparser::ImportSectionEntryType,
     ) -> EntityType {
-        let module = self.get_aliased(cx).unwrap_or(self);
-        let types_space = match &cx.arena[module.id] {
-            ModuleInfo::Aliased(_) => unreachable!(),
-            ModuleInfo::Defined(d) => &d.types,
-        };
-        cx.types().entity_type(ty, types_space)
+        cx.types().entity_type(ty, &cx.defined(self).types)
     }
 
     /// Add a new raw section to this module info during parsing.

--- a/src/info.rs
+++ b/src/info.rs
@@ -4,65 +4,115 @@ use crate::translate;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
+/// A collection of info about modules within a module linking bundle.
+#[derive(Default)]
+pub(crate) struct ModuleContext<'a> {
+    arena: Vec<ModuleInfo<'a>>,
+}
+
+impl<'a> ModuleContext<'a> {
+    /// Construct a new `ModuleContext`, pre-populated with an empty root
+    /// module.
+    pub fn new() -> Self {
+        Self {
+            arena: vec![ModuleInfo::Defined(DefinedModuleInfo::default())],
+        }
+    }
+
+    /// Get the root module.
+    pub fn root(&self) -> Module {
+        Module { id: 0 }
+    }
+
+    /// Get a shared reference to the `DefinedModuleInfo` for this module,
+    /// following through aliases.
+    fn resolve(&self, module: Module) -> &DefinedModuleInfo<'a> {
+        let mut id = module.id;
+        loop {
+            match &self.arena[id] {
+                ModuleInfo::Aliased(AliasedModuleInfo { alias_of, .. }) => {
+                    id = *alias_of;
+                }
+                ModuleInfo::Defined(d) => return d,
+            }
+        }
+    }
+
+    /// Get an exclusive reference to the `DefinedModuleInfo` for this module.
+    ///
+    /// Does not resolve through aliases, because you shouldn't ever mutate
+    /// aliased modules.
+    fn defined_mut(&mut self, module: Module) -> &mut DefinedModuleInfo<'a> {
+        match &mut self.arena[module.id] {
+            ModuleInfo::Aliased(_) => panic!("not a defined module"),
+            ModuleInfo::Defined(d) => d,
+        }
+    }
+}
+
+enum ModuleInfo<'a> {
+    Aliased(AliasedModuleInfo),
+    Defined(DefinedModuleInfo<'a>),
+}
+
+struct AliasedModuleInfo {
+    /// This module's id.
+    pub id: usize,
+    /// The id of the other module that this is an alias of.
+    pub alias_of: usize,
+}
+
 /// Info that we keep track of on a per module-within-a-module-linking-bundle
 /// basis.
 ///
 /// These are created during during our `parse` pass and then used throughout
 /// our later passes.
-#[derive(Clone, Default)]
-pub(crate) struct ModuleInfo<'a> {
-    /// This module's id (i.e. its pre-order traversal index).
-    pub id: u32,
-
+#[derive(Default)]
+struct DefinedModuleInfo<'a> {
     /// The raw sections from the original Wasm input.
-    pub raw_sections: Vec<wasm_encoder::RawSection<'a>>,
+    raw_sections: Vec<wasm_encoder::RawSection<'a>>,
 
     /// This vector has `n` entries when the module has `n` import sections. The
     /// `i`th entry is a count of how many instance imports are in the `i`th
     /// import section.
-    pub instance_import_counts: Vec<u32>,
+    instance_import_counts: Vec<u32>,
 
     /// Types available in this module.
     ///
     /// We keep track of these for determining how many things we need to
     /// re-export for new instantiations and for inner module's aliases.
-    pub types: Vec<wasmparser::TypeDef<'a>>,
+    types: Vec<wasmparser::TypeDef<'a>>,
 
     /// Imports made by this module.
-    pub imports: Vec<wasmparser::Import<'a>>,
+    imports: Vec<wasmparser::Import<'a>>,
 
     /// Aliases that this module defines.
-    pub aliases: Vec<wasmparser::Alias<'a>>,
-
-    /// How many more not-yet-parsed child modules are expected for this module?
-    ///
-    /// This is only used during parsing.
-    pub child_modules_expected: u32,
+    aliases: Vec<wasmparser::Alias<'a>>,
 
     /// Directly nested inner modules of this module.
     ///
     /// These entries are populated as we finish instrumenting the inner
     /// modules.
-    pub modules: Vec<ModuleInfo<'a>>,
+    modules: Vec<Module>,
 
     /// A map from instance indices to each instance's type for all defined,
     /// imported, and aliased instances.
-    pub instances: Vec<wasmparser::InstanceType<'a>>,
+    instances: Vec<wasmparser::InstanceType<'a>>,
 
     /// A map from indices of defined instantiations (as opposed to imported or
     /// aliased instantiations) to the id of the module that was instantiated
     /// and the import arguments.
-    pub instantiations: BTreeMap<u32, (u32, Vec<wasmparser::InstanceArg<'a>>)>,
+    instantiations: BTreeMap<u32, (Module, Vec<wasmparser::InstanceArg<'a>>)>,
 
     /// A map from global indices to each global's type for all defined,
     /// imported, and aliased globals.
-    pub globals: Vec<wasmparser::GlobalType>,
+    globals: Vec<wasmparser::GlobalType>,
 
     /// The index within the global index space where defined globals (as
     /// opposed to imported or aliased) begin.
     ///
     /// If this is `None`, then there are no locally defined globals.
-    pub defined_globals_index: Option<u32>,
+    defined_globals_index: Option<u32>,
 
     /// This module's exports.
     ///
@@ -71,62 +121,208 @@ pub(crate) struct ModuleInfo<'a> {
     ///
     /// Note that this does *not* include the `__wizer_thing_N` exports that
     /// this instrumentation pass adds.
-    pub exports: Vec<wasmparser::Export<'a>>,
-
-    /// A currently-being-encoded module section.
-    ///
-    /// As we finish instrumenting child modules, we add them here. If we aren't
-    /// currently processing this module's children, then this is `None`.
-    pub module_section: Option<wasm_encoder::ModuleSection>,
+    exports: Vec<wasmparser::Export<'a>>,
 
     /// Maps from function index to the function's type index for all functions
     /// defined, imported, and aliased in this module.
-    pub functions: Vec<u32>,
+    functions: Vec<u32>,
 
     /// Maps from table index to the table's type for all tables defined,
     /// imported, and aliased in this module.
-    pub tables: Vec<wasmparser::TableType>,
+    tables: Vec<wasmparser::TableType>,
 
     /// Maps from memory index to the memory's type for all memories defined,
     /// imported, and aliased in this module.
-    pub memories: Vec<wasmparser::MemoryType>,
+    memories: Vec<wasmparser::MemoryType>,
 
     /// The index within the memory index space where defined memories (as
     /// opposed to imported or aliased) begin.
     ///
     /// If this is `None`, then there are no locally defined memories.
-    pub defined_memories_index: Option<u32>,
+    defined_memories_index: Option<u32>,
 }
 
-impl<'a> ModuleInfo<'a> {
-    /// Create the `ModuleInfo` for the root of a module-linking bundle.
-    pub fn for_root() -> Self {
-        Self::default()
+/// A module inside a module linking bundle.
+///
+/// This is a small, copy-able type that essentially just indexes into a
+/// `ModuleContext`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct Module {
+    /// This module's id, aka its pre-order traversal index, aka its index in
+    /// `Modules::arena`.
+    id: usize,
+}
+
+impl Module {
+    /// Construct a new, defined module.
+    pub fn new_defined(cx: &mut ModuleContext) -> Self {
+        let id = cx.arena.len();
+        cx.arena.push(ModuleInfo::Defined(Default::default()));
+        Module { id }
     }
 
-    /// Create a new `ModuleInfo` for an inner module.
-    pub fn for_inner(id: u32) -> Self {
-        Self {
+    /// Construct a new module that is an alias of the given module.
+    pub fn new_aliased(cx: &mut ModuleContext, alias_of: Module) -> Self {
+        let id = cx.arena.len();
+        cx.arena.push(ModuleInfo::Aliased(AliasedModuleInfo {
             id,
-            ..Self::default()
-        }
+            alias_of: alias_of.id,
+        }));
+        Module { id }
+    }
+
+    /// Get the pre-order traversal index of this module in its associated
+    /// module linking bundle.
+    pub fn pre_order_index(self) -> u32 {
+        u32::try_from(self.id).unwrap()
     }
 
     /// Add a new raw section to this module info during parsing.
-    pub fn add_raw_section(
-        &mut self,
+    pub fn add_raw_section<'a>(
+        self,
+        cx: &mut ModuleContext<'a>,
         id: SectionId,
         range: wasmparser::Range,
         full_wasm: &'a [u8],
     ) {
-        self.raw_sections.push(wasm_encoder::RawSection {
-            id: id as u8,
-            data: &full_wasm[range.start..range.end],
-        })
+        cx.defined_mut(self)
+            .raw_sections
+            .push(wasm_encoder::RawSection {
+                id: id as u8,
+                data: &full_wasm[range.start..range.end],
+            })
+    }
+
+    /// Push a new type into this module's types space.
+    pub fn push_type<'a>(self, cx: &mut ModuleContext<'a>, ty: wasmparser::TypeDef<'a>) {
+        cx.defined_mut(self).types.push(ty);
+    }
+
+    /// Push a new module onto this module's list of nested child modules.
+    pub fn push_child_module(self, cx: &mut ModuleContext<'_>, child: Module) {
+        cx.defined_mut(self).modules.push(child);
+    }
+
+    /// Push a new, aliased instance into this module's instance index space.
+    pub fn push_aliased_instance<'a>(
+        self,
+        cx: &mut ModuleContext<'a>,
+        instance_type: wasmparser::InstanceType<'a>,
+    ) {
+        cx.defined_mut(self).instances.push(instance_type);
+    }
+
+    /// Push a new, imported instance into this module's instance index space.
+    pub fn push_imported_instance<'a>(
+        self,
+        cx: &mut ModuleContext<'a>,
+        instance_type: wasmparser::InstanceType<'a>,
+    ) {
+        cx.defined_mut(self).instances.push(instance_type);
+    }
+
+    /// Push a new, imported instance into this module's instance index space.
+    pub fn push_defined_instance<'a>(
+        self,
+        cx: &mut ModuleContext<'a>,
+        instance_type: wasmparser::InstanceType<'a>,
+        module: Module,
+        args: Vec<wasmparser::InstanceArg<'a>>,
+    ) {
+        let info = cx.defined_mut(self);
+        let index = u32::try_from(info.instances.len()).unwrap();
+        info.instances.push(instance_type);
+        info.instantiations.insert(index, (module, args));
+    }
+
+    /// Push a new imported memory into this module's memory index space.
+    pub fn push_imported_memory(self, cx: &mut ModuleContext, memory_type: wasmparser::MemoryType) {
+        let info = cx.defined_mut(self);
+        assert!(info.defined_memories_index.is_none());
+        info.memories.push(memory_type);
+    }
+
+    /// Push a new defined memory into this module's memory index space.
+    pub fn push_defined_memory(self, cx: &mut ModuleContext, memory_type: wasmparser::MemoryType) {
+        let info = cx.defined_mut(self);
+        if info.defined_memories_index.is_none() {
+            info.defined_memories_index = Some(u32::try_from(info.memories.len()).unwrap());
+        }
+        info.memories.push(memory_type);
+    }
+
+    /// Push a new imported global into this module's global index space.
+    pub fn push_imported_global(self, cx: &mut ModuleContext, global_type: wasmparser::GlobalType) {
+        let info = cx.defined_mut(self);
+        assert!(info.defined_globals_index.is_none());
+        info.globals.push(global_type);
+    }
+
+    /// Push a new defined global into this module's global index space.
+    pub fn push_defined_global(self, cx: &mut ModuleContext, global_type: wasmparser::GlobalType) {
+        let info = cx.defined_mut(self);
+        if info.defined_globals_index.is_none() {
+            info.defined_globals_index = Some(u32::try_from(info.globals.len()).unwrap());
+        }
+        info.globals.push(global_type);
+    }
+
+    /// Push a new function into this module's function index space.
+    pub fn push_function(self, cx: &mut ModuleContext, func_type: u32) {
+        cx.defined_mut(self).functions.push(func_type);
+    }
+
+    /// Push a new table into this module's table index space.
+    pub fn push_table(self, cx: &mut ModuleContext, table_type: wasmparser::TableType) {
+        cx.defined_mut(self).tables.push(table_type);
+    }
+
+    /// Push a new import into this module.
+    pub fn push_import<'a>(self, cx: &mut ModuleContext<'a>, import: wasmparser::Import<'a>) {
+        cx.defined_mut(self).imports.push(import);
+
+        // Add the import to the appropriate index space for our current module.
+        match import.ty {
+            wasmparser::ImportSectionEntryType::Memory(ty) => {
+                self.push_imported_memory(cx, ty);
+            }
+            wasmparser::ImportSectionEntryType::Global(ty) => {
+                self.push_imported_global(cx, ty);
+            }
+            wasmparser::ImportSectionEntryType::Instance(ty_idx) => {
+                let ty = self.instance_type_at(cx, ty_idx).clone();
+                self.push_imported_instance(cx, ty);
+            }
+            wasmparser::ImportSectionEntryType::Function(func_ty) => {
+                self.push_function(cx, func_ty);
+            }
+            wasmparser::ImportSectionEntryType::Table(ty) => {
+                self.push_table(cx, ty);
+            }
+            wasmparser::ImportSectionEntryType::Module(_)
+            | wasmparser::ImportSectionEntryType::Event(_) => {
+                unreachable!()
+            }
+        }
+    }
+
+    /// Push a count of how many instance imports an import section had.
+    pub fn push_instance_import_count(self, cx: &mut ModuleContext, count: u32) {
+        cx.defined_mut(self).instance_import_counts.push(count);
+    }
+
+    /// Push an alias into this module.
+    pub fn push_alias<'a>(self, cx: &mut ModuleContext<'a>, alias: wasmparser::Alias<'a>) {
+        cx.defined_mut(self).aliases.push(alias);
+    }
+
+    /// Push an export into this module.
+    pub fn push_export<'a>(self, cx: &mut ModuleContext<'a>, export: wasmparser::Export<'a>) {
+        cx.defined_mut(self).exports.push(export);
     }
 
     /// Is this the root of the module linking bundle?
-    pub fn is_root(&self) -> bool {
+    pub fn is_root(self) -> bool {
         self.id == 0
     }
 
@@ -135,29 +331,31 @@ impl<'a> ModuleInfo<'a> {
     /// Returns the index of the type and updates the total count of types in
     /// `num_types`.
     pub fn define_instance_type(
-        &self,
+        self,
+        cx: &ModuleContext<'_>,
         num_types: &mut u32,
         types: &mut wasm_encoder::TypeSection,
     ) -> u32 {
         let ty_index = *num_types;
-        types.instance(self.exports.iter().map(|e| {
+        let info = cx.resolve(self);
+        types.instance(info.exports.iter().map(|e| {
             let name = e.field;
             let index = usize::try_from(e.index).unwrap();
             let item = match e.kind {
                 wasmparser::ExternalKind::Function => {
-                    let func_ty = self.functions[index];
+                    let func_ty = info.functions[index];
                     wasm_encoder::EntityType::Function(func_ty)
                 }
                 wasmparser::ExternalKind::Table => {
-                    let ty = self.tables[index];
+                    let ty = info.tables[index];
                     wasm_encoder::EntityType::Table(translate::table_type(ty))
                 }
                 wasmparser::ExternalKind::Memory => {
-                    let ty = self.memories[index];
+                    let ty = info.memories[index];
                     wasm_encoder::EntityType::Memory(translate::memory_type(ty))
                 }
                 wasmparser::ExternalKind::Global => {
-                    let ty = self.globals[index];
+                    let ty = info.globals[index];
                     wasm_encoder::EntityType::Global(translate::global_type(ty))
                 }
                 wasmparser::ExternalKind::Instance => wasm_encoder::EntityType::Instance(e.index),
@@ -172,9 +370,10 @@ impl<'a> ModuleInfo<'a> {
     }
 
     /// Construct an instance type for instances of this module.
-    pub fn instance_type(&self) -> wasmparser::InstanceType<'a> {
+    pub fn instance_type<'a>(self, cx: &ModuleContext<'a>) -> wasmparser::InstanceType<'a> {
+        let info = cx.resolve(self);
         wasmparser::InstanceType {
-            exports: self
+            exports: info
                 .exports
                 .iter()
                 .map(|e| {
@@ -183,19 +382,19 @@ impl<'a> ModuleInfo<'a> {
                         name: e.field,
                         ty: match e.kind {
                             wasmparser::ExternalKind::Function => {
-                                let func_ty = self.functions[index];
+                                let func_ty = info.functions[index];
                                 wasmparser::ImportSectionEntryType::Function(func_ty)
                             }
                             wasmparser::ExternalKind::Table => {
-                                let ty = self.tables[index];
+                                let ty = info.tables[index];
                                 wasmparser::ImportSectionEntryType::Table(ty)
                             }
                             wasmparser::ExternalKind::Memory => {
-                                let ty = self.memories[index];
+                                let ty = info.memories[index];
                                 wasmparser::ImportSectionEntryType::Memory(ty)
                             }
                             wasmparser::ExternalKind::Global => {
-                                let ty = self.globals[index];
+                                let ty = info.globals[index];
                                 wasmparser::ImportSectionEntryType::Global(ty)
                             }
                             wasmparser::ExternalKind::Instance => {
@@ -211,14 +410,27 @@ impl<'a> ModuleInfo<'a> {
         }
     }
 
+    /// Get the count of how many instance imports are in each import section in
+    /// this module.
+    pub fn instance_import_counts<'b>(self, cx: &'b ModuleContext<'_>) -> &'b [u32] {
+        &cx.resolve(self).instance_import_counts
+    }
+
+    /// Get the aliases defined in this module.
+    pub fn aliases<'a, 'b>(self, cx: &'b ModuleContext<'a>) -> &'b [wasmparser::Alias<'a>] {
+        &cx.resolve(self).aliases
+    }
+
     /// Get an export from the `n`th instance by name.
     pub fn instance_export(
-        &self,
+        self,
+        cx: &ModuleContext<'_>,
         instance: u32,
         name: &str,
     ) -> Option<wasmparser::ImportSectionEntryType> {
         let instance = usize::try_from(instance).unwrap();
-        let instance = &self.instances[instance];
+        let info = cx.resolve(self);
+        let instance = &info.instances[instance];
         instance
             .exports
             .iter()
@@ -227,62 +439,91 @@ impl<'a> ModuleInfo<'a> {
     }
 
     /// Do a pre-order traversal over this module tree.
-    pub fn pre_order<'b, F>(&'b self, mut f: F)
+    pub fn pre_order<F>(self, cx: &ModuleContext<'_>, mut f: F)
     where
-        F: FnMut(&'b ModuleInfo<'a>),
+        F: FnMut(Module),
     {
         let mut stack = vec![self];
-        while let Some(info) = stack.pop() {
-            f(info);
-            stack.extend(info.modules.iter().rev());
+        while let Some(module) = stack.pop() {
+            f(module);
+            let info = cx.resolve(module);
+            stack.extend(info.modules.iter().copied().rev());
         }
     }
 
+    /// Get the first index in the memory space where a memory is defined rather
+    /// than aliased or imported.
+    pub fn defined_memories_index(self, cx: &ModuleContext) -> Option<u32> {
+        cx.resolve(self).defined_memories_index
+    }
+
     /// The number of defined memories in this module.
-    pub fn defined_memories_len(&self) -> usize {
-        self.defined_memories_index.map_or(0, |n| {
+    pub fn defined_memories_len(self, cx: &ModuleContext) -> usize {
+        let info = cx.resolve(self);
+        info.defined_memories_index.map_or(0, |n| {
             let n = usize::try_from(n).unwrap();
-            assert!(self.memories.len() > n);
-            self.memories.len() - n
+            assert!(info.memories.len() > n);
+            info.memories.len() - n
         })
     }
 
     /// Iterate over the defined memories in this module.
-    pub fn defined_memories<'b>(&'b self) -> impl Iterator<Item = wasmparser::MemoryType> + 'b {
-        self.memories
+    pub fn defined_memories<'b>(
+        self,
+        cx: &'b ModuleContext<'_>,
+    ) -> impl Iterator<Item = (u32, wasmparser::MemoryType)> + 'b {
+        let info = cx.resolve(self);
+        info.memories
             .iter()
-            .skip(
-                self.defined_memories_index
-                    .map_or(self.memories.len(), |i| usize::try_from(i).unwrap()),
-            )
             .copied()
+            .enumerate()
+            .skip(
+                info.defined_memories_index
+                    .map_or(info.memories.len(), |i| usize::try_from(i).unwrap()),
+            )
+            .map(|(i, m)| (u32::try_from(i).unwrap(), m))
+    }
+
+    /// Get the first index in the global space where a global is defined rather
+    /// than aliased or imported.
+    pub fn defined_globals_index(self, cx: &ModuleContext) -> Option<u32> {
+        cx.resolve(self).defined_globals_index
     }
 
     /// The number of defined globals in this module.
-    pub fn defined_globals_len(&self) -> usize {
-        self.defined_globals_index.map_or(0, |n| {
+    pub fn defined_globals_len(self, cx: &ModuleContext<'_>) -> usize {
+        let info = cx.resolve(self);
+        info.defined_globals_index.map_or(0, |n| {
             let n = usize::try_from(n).unwrap();
-            assert!(self.globals.len() > n);
-            self.globals.len() - n
+            assert!(info.globals.len() > n);
+            info.globals.len() - n
         })
     }
 
     /// Iterate over the defined globals in this module.
-    pub fn defined_globals<'b>(&'b self) -> impl Iterator<Item = wasmparser::GlobalType> + 'b {
-        self.globals
+    pub fn defined_globals<'b>(
+        self,
+        cx: &'b ModuleContext<'_>,
+    ) -> impl Iterator<Item = (u32, wasmparser::GlobalType)> + 'b {
+        let info = cx.resolve(self);
+        info.globals
             .iter()
-            .skip(
-                self.defined_globals_index
-                    .map_or(self.globals.len(), |i| usize::try_from(i).unwrap()),
-            )
             .copied()
+            .enumerate()
+            .skip(
+                info.defined_globals_index
+                    .map_or(info.globals.len(), |i| usize::try_from(i).unwrap()),
+            )
+            .map(|(i, g)| (u32::try_from(i).unwrap(), g))
     }
 
     /// Iterate over the initial sections in this Wasm module.
-    pub fn initial_sections<'b>(
-        &'b self,
-    ) -> impl Iterator<Item = &'b wasm_encoder::RawSection> + 'b {
-        self.raw_sections
+    pub fn initial_sections<'a, 'b>(
+        self,
+        cx: &'b ModuleContext<'a>,
+    ) -> impl Iterator<Item = &'b wasm_encoder::RawSection<'a>> + 'b {
+        let info = cx.resolve(self);
+        info.raw_sections
             .iter()
             .filter(|s| s.id != SectionId::Custom.into())
             .take_while(|s| match s.id {
@@ -293,5 +534,77 @@ impl<'a> ModuleInfo<'a> {
                 x if x == SectionId::Instance.into() => true,
                 _ => false,
             })
+    }
+
+    /// Get a slice of this module's original raw sections.
+    pub fn raw_sections<'a, 'b>(
+        self,
+        cx: &'b ModuleContext<'a>,
+    ) -> &'b [wasm_encoder::RawSection<'a>] {
+        &cx.resolve(self).raw_sections
+    }
+
+    /// Get a slice of this module's nested child modules.
+    pub fn child_modules<'b>(self, cx: &'b ModuleContext<'_>) -> &'b [Module] {
+        &cx.resolve(self).modules
+    }
+
+    /// Get a slice of this module's exports.
+    pub fn exports<'a, 'b>(self, cx: &'b ModuleContext<'a>) -> &'b [wasmparser::Export<'a>] {
+        &cx.resolve(self).exports
+    }
+
+    /// Get a slice of this module's imports.
+    pub fn imports<'a, 'b>(self, cx: &'b ModuleContext<'a>) -> &'b [wasmparser::Import<'a>] {
+        &cx.resolve(self).imports
+    }
+
+    /// Get this module's defined (as opposed to imported or aliased)
+    /// instantiations.
+    ///
+    /// The return value maps an instance index to the module that was
+    /// instantiated and the associated instantiation arguments.
+    pub fn instantiations<'a, 'b>(
+        self,
+        cx: &'b ModuleContext<'a>,
+    ) -> &'b BTreeMap<u32, (Module, Vec<wasmparser::InstanceArg<'a>>)> {
+        &cx.resolve(self).instantiations
+    }
+
+    /// Get this module's `n`th nested child module.
+    pub fn child_module_at(self, cx: &ModuleContext<'_>, n: u32) -> Module {
+        cx.resolve(self).modules[usize::try_from(n).unwrap()]
+    }
+
+    /// Get the full types index space for this module.
+    pub fn types<'a, 'b>(self, cx: &'b ModuleContext<'a>) -> &'b [wasmparser::TypeDef<'a>] {
+        &cx.resolve(self).types
+    }
+
+    /// Get the type at the given index.
+    ///
+    /// Panics if the types index space does not contain the given index.
+    pub fn type_at<'a, 'b>(
+        self,
+        cx: &'b ModuleContext<'a>,
+        type_index: u32,
+    ) -> &'b wasmparser::TypeDef<'a> {
+        &cx.resolve(self).types[usize::try_from(type_index).unwrap()]
+    }
+
+    /// Get the instance type at the given type index.
+    ///
+    /// Panics if the types index space does not contain the given index or the
+    /// type at the index is not an instance type.
+    pub fn instance_type_at<'a, 'b>(
+        self,
+        cx: &'b ModuleContext<'a>,
+        type_index: u32,
+    ) -> &'b wasmparser::InstanceType<'a> {
+        if let wasmparser::TypeDef::Instance(ity) = self.type_at(cx, type_index) {
+            ity
+        } else {
+            panic!("not an instance type")
+        }
     }
 }

--- a/src/info/types_interner.rs
+++ b/src/info/types_interner.rs
@@ -1,0 +1,205 @@
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+    convert::TryFrom,
+    rc::Rc,
+};
+
+/// A de-duplicated set of type definitions.
+///
+/// We insert new entries via hash consing, to de-duplicate entries.
+///
+/// This is shared across all modules in a module linking bundle.
+///
+/// We assign and track a unique index for each type we insert. These end up
+/// being the indices of each type in the root Wasm module. All nested modules
+/// refer to these types, and pull them into their nested types index space, via
+/// outer type aliases.
+#[derive(Default)]
+pub struct TypesInterner<'a> {
+    /// The interned types.
+    types: Vec<Rc<Type<'a>>>,
+
+    /// An map from a type to its index in `self.types`.
+    type_to_index: HashMap<Rc<Type<'a>>, u32>,
+}
+
+/// An interned Wasm type definition.
+#[derive(PartialEq, Eq, Hash)]
+pub enum Type<'a> {
+    Func(wasmparser::FuncType),
+    Instance(InstanceType<'a>),
+    Module(ModuleType<'a>),
+}
+
+impl Type<'_> {
+    pub fn is_instance(&self) -> bool {
+        matches!(self, Type::Instance(_))
+    }
+
+    pub fn is_func(&self) -> bool {
+        matches!(self, Type::Func(_))
+    }
+}
+
+/// An interned Wasm instance type.
+#[derive(PartialEq, Eq, Hash)]
+pub struct InstanceType<'a> {
+    pub exports: BTreeMap<Cow<'a, str>, EntityType>,
+}
+
+/// An interned type for some kind of Wasm entity.
+#[derive(PartialEq, Eq, Hash)]
+pub enum EntityType {
+    Function(TypeId),
+    Table(wasmparser::TableType),
+    Memory(wasmparser::MemoryType),
+    Global(wasmparser::GlobalType),
+    Module(TypeId),
+    Instance(TypeId),
+}
+
+/// An interned Wasm module type.
+#[derive(PartialEq, Eq, Hash)]
+pub struct ModuleType<'a> {
+    pub imports: BTreeMap<(Cow<'a, str>, Option<Cow<'a, str>>), EntityType>,
+    pub exports: BTreeMap<Cow<'a, str>, EntityType>,
+}
+
+/// An id of a type in a `TypesInterner` type set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TypeId {
+    index: u32,
+}
+
+impl TypeId {
+    /// Get the index of this type inside its `TypesInterner`.
+    ///
+    /// This index is *not* the same as the index within a particular module's
+    /// index space, it is within the `TypesInterner`'s index space (except for
+    /// the eventual umbrella module, whose types index space matches the
+    /// interner's index space).
+    pub fn index(self) -> u32 {
+        self.index
+    }
+}
+
+impl<'a> TypesInterner<'a> {
+    /// Iterate over the types defined in this type set and their index.
+    pub fn iter<'b>(&'b self) -> impl Iterator<Item = (u32, &'b Type<'a>)> + 'b {
+        assert!((self.types.len() as u64) < (u32::MAX as u64));
+        self.types
+            .iter()
+            .enumerate()
+            .map(|(idx, ty)| (u32::try_from(idx).unwrap(), &**ty))
+    }
+
+    /// Get a type by id.
+    pub fn get(&self, id: TypeId) -> &Type<'a> {
+        &*self.types[usize::try_from(id.index).unwrap()]
+    }
+
+    /// Intern a `wasmparser` type into this type set and get its id.
+    ///
+    /// The provided `types_space` must be a slice of the defining module's
+    /// types index space.
+    ///
+    /// If the type has already been inserted and assigned an id before, then
+    /// that entry and its id are reused.
+    pub fn insert_wasmparser(
+        &mut self,
+        ty: wasmparser::TypeDef<'a>,
+        types_space: &[TypeId],
+    ) -> TypeId {
+        match ty {
+            wasmparser::TypeDef::Func(func_ty) => self.insert(Type::Func(func_ty)),
+            wasmparser::TypeDef::Instance(inst_ty) => {
+                self.insert_wasmparser_instance_type(inst_ty, types_space)
+            }
+            wasmparser::TypeDef::Module(module_ty) => {
+                self.insert_wasmparser_module_type(module_ty, types_space)
+            }
+        }
+    }
+
+    /// Insert a new type into this type set and get its id.
+    ///
+    /// If the type has already been inserted and assigned an id before, then
+    /// that entry and its id are reused.
+    pub fn insert(&mut self, ty: Type<'a>) -> TypeId {
+        if let Some(index) = self.type_to_index.get(&ty).copied() {
+            return TypeId { index };
+        }
+
+        let index = u32::try_from(self.types.len()).unwrap();
+        let ty = Rc::new(ty);
+        self.type_to_index.insert(ty.clone(), index);
+        self.types.push(ty);
+        TypeId { index }
+    }
+
+    /// Convert a `wasmparser::ImportSectionEntryType` into an interned
+    /// `EntityType`.
+    ///
+    /// The provided `types_space` must be a slice of the defining module's
+    /// types index space.
+    pub fn entity_type(
+        &self,
+        ty: wasmparser::ImportSectionEntryType,
+        types_space: &[TypeId],
+    ) -> EntityType {
+        match ty {
+            wasmparser::ImportSectionEntryType::Function(idx) => {
+                EntityType::Function(types_space[usize::try_from(idx).unwrap()])
+            }
+            wasmparser::ImportSectionEntryType::Table(ty) => EntityType::Table(ty),
+            wasmparser::ImportSectionEntryType::Memory(ty) => EntityType::Memory(ty),
+            wasmparser::ImportSectionEntryType::Global(ty) => EntityType::Global(ty),
+            wasmparser::ImportSectionEntryType::Module(idx) => {
+                EntityType::Module(types_space[usize::try_from(idx).unwrap()])
+            }
+            wasmparser::ImportSectionEntryType::Instance(idx) => {
+                EntityType::Instance(types_space[usize::try_from(idx).unwrap()])
+            }
+            wasmparser::ImportSectionEntryType::Event(_) => unreachable!(),
+        }
+    }
+
+    fn insert_wasmparser_instance_type(
+        &mut self,
+        inst_ty: wasmparser::InstanceType<'a>,
+        types_space: &[TypeId],
+    ) -> TypeId {
+        self.insert(Type::Instance(InstanceType {
+            exports: inst_ty
+                .exports
+                .iter()
+                .map(|exp| (exp.name.into(), self.entity_type(exp.ty, types_space)))
+                .collect(),
+        }))
+    }
+
+    fn insert_wasmparser_module_type(
+        &mut self,
+        module_ty: wasmparser::ModuleType<'a>,
+        types_space: &[TypeId],
+    ) -> TypeId {
+        self.insert(Type::Module(ModuleType {
+            imports: module_ty
+                .imports
+                .iter()
+                .map(|imp| {
+                    (
+                        (imp.module.into(), imp.field.map(Cow::from)),
+                        self.entity_type(imp.ty, types_space),
+                    )
+                })
+                .collect(),
+            exports: module_ty
+                .exports
+                .iter()
+                .map(|exp| (exp.name.into(), self.entity_type(exp.ty, types_space)))
+                .collect(),
+        }))
+    }
+}

--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -1,0 +1,252 @@
+//! The initial instrumentation pass.
+
+use crate::info::ModuleInfo;
+use crate::stack_ext::StackExt;
+use std::convert::TryFrom;
+use wasm_encoder::SectionId;
+
+/// Instrument the input Wasm so that it exports its memories and globals,
+/// allowing us to inspect their state after the module is instantiated and
+/// initialized.
+///
+/// For example, given this input module:
+///
+/// ```wat
+/// (module $A
+///   (module $B
+///     (memory $B_mem)
+///     (global $B_glob (mut i32))
+///   )
+///
+///   (instance $x (instantiate $B))
+///   (instance $y (instantiate $B))
+///
+///   (memory $A_mem)
+///   (global $A_glob (mut i32))
+/// )
+/// ```
+///
+/// this pass will produce the following instrumented module:
+///
+/// ```wat
+/// (module $A
+///   (module $B
+///     (memory $B_mem)
+///     (global $B_glob (mut i32))
+///
+///     ;; Export all state.
+///     (export "__wizer_memory_0" (memory $B_mem))
+///     (export "__wizer_global_0" (global $B_glob))
+///   )
+///
+///   (instance $x (instantiate $B))
+///   (instance $y (instantiate $B))
+///
+///   (memory $A_mem)
+///   (global $A_glob (mut i32))
+///
+///   ;; Export of all state (including transitively re-exporting nested
+///   ;; instantiations' state).
+///   (export "__wizer_memory_0" (memory $A_mem))
+///   (export "__wizer_global_0" (global $A_glob))
+///   (export "__wizer_instance_0" (instance $x))
+///   (export "__wizer_instance_1" (instance $y))
+/// )
+/// ```
+///
+/// NB: we re-export nested instantiations as a whole instance export because we
+/// can do this without disturbing existing isntances' indices. If we were to
+/// export their memories and globals individually, that would disturb the
+/// modules locally defined memoryies' and globals' indices, which would require
+/// rewriting the code section, which would break debug info offsets.
+pub(crate) fn instrument(root_info: &ModuleInfo) -> Vec<u8> {
+    log::debug!("Instrumenting the input Wasm");
+
+    struct StackEntry<'a> {
+        /// This entry's module info.
+        info: &'a ModuleInfo<'a>,
+
+        /// The work-in-progress encoding of the new, instrumented module.
+        module: wasm_encoder::Module,
+
+        /// Sections in this module info that we are iterating over.
+        sections: std::slice::Iter<'a, wasm_encoder::RawSection<'a>>,
+
+        /// The index of this entry's parent module on the stack. `None` if this
+        /// is the root module.
+        parent_index: Option<usize>,
+
+        /// Nested child modules that still need to be instrumented and added to
+        /// one of this entry's module's module sections.
+        children: std::slice::Iter<'a, ModuleInfo<'a>>,
+
+        /// The current module section we are building for this entry's
+        /// module. Only `Some` if we are currently processing this module's
+        /// (transitive) children, i.e. this is not the module on the top of the
+        /// stack.
+        module_section: Option<wasm_encoder::ModuleSection>,
+
+        /// The number of children still remaining to be interested for the
+        /// current module section.
+        children_remaining: usize,
+    }
+
+    let mut stack = vec![StackEntry {
+        info: root_info,
+        module: wasm_encoder::Module::new(),
+        sections: root_info.raw_sections.iter(),
+        parent_index: None,
+        children: root_info.modules.iter(),
+        module_section: None,
+        children_remaining: 0,
+    }];
+
+    loop {
+        assert!(!stack.is_empty());
+
+        match stack.top_mut().sections.next() {
+            // For the exports section, we need to transitively export internal
+            // state so that we can read the initialized state after we call the
+            // initialization function.
+            Some(section) if section.id == SectionId::Export.into() => {
+                let entry = stack.top_mut();
+                let mut exports = wasm_encoder::ExportSection::new();
+
+                // First, copy over all the original exports.
+                for export in &entry.info.exports {
+                    exports.export(
+                        export.field,
+                        match export.kind {
+                            wasmparser::ExternalKind::Function => {
+                                wasm_encoder::Export::Function(export.index)
+                            }
+                            wasmparser::ExternalKind::Table => {
+                                wasm_encoder::Export::Table(export.index)
+                            }
+                            wasmparser::ExternalKind::Memory => {
+                                wasm_encoder::Export::Memory(export.index)
+                            }
+                            wasmparser::ExternalKind::Global => {
+                                wasm_encoder::Export::Global(export.index)
+                            }
+                            wasmparser::ExternalKind::Instance => {
+                                wasm_encoder::Export::Instance(export.index)
+                            }
+                            wasmparser::ExternalKind::Module
+                            | wasmparser::ExternalKind::Type
+                            | wasmparser::ExternalKind::Event => {
+                                unreachable!("should have been rejected in validation/parsing")
+                            }
+                        },
+                    );
+                }
+
+                // Now export all of this module's defined globals, memories,
+                // and instantiations under well-known names so we can inspect
+                // them after initialization.
+                for (i, j) in (entry.info.defined_globals_index.unwrap_or(u32::MAX)
+                    ..u32::try_from(entry.info.globals.len()).unwrap())
+                    .enumerate()
+                {
+                    let name = format!("__wizer_global_{}", i);
+                    exports.export(&name, wasm_encoder::Export::Global(j));
+                }
+                for (i, j) in (entry.info.defined_memories_index.unwrap_or(u32::MAX)
+                    ..u32::try_from(entry.info.memories.len()).unwrap())
+                    .enumerate()
+                {
+                    let name = format!("__wizer_memory_{}", i);
+                    exports.export(&name, wasm_encoder::Export::Memory(j));
+                }
+                for (i, j) in entry.info.instantiations.keys().enumerate() {
+                    let name = format!("__wizer_instance_{}", i);
+                    exports.export(&name, wasm_encoder::Export::Instance(*j));
+                }
+
+                entry.module.section(&exports);
+            }
+
+            // Nested module sections need to recursively instrument each child
+            // module.
+            Some(section) if section.id == SectionId::Module.into() => {
+                let reader = wasmparser::ModuleSectionReader::new(section.data, 0).unwrap();
+                let count = usize::try_from(reader.get_count()).unwrap();
+
+                assert!(stack.top().module_section.is_none());
+                if count == 0 {
+                    continue;
+                }
+
+                stack.top_mut().module_section = Some(wasm_encoder::ModuleSection::new());
+
+                assert_eq!(stack.top().children_remaining, 0);
+                stack.top_mut().children_remaining = count;
+
+                let children = stack
+                    .top_mut()
+                    .children
+                    .by_ref()
+                    .take(count)
+                    .collect::<Vec<_>>();
+
+                assert_eq!(
+                    children.len(),
+                    count,
+                    "shouldn't ever have fewer children than expected"
+                );
+
+                let parent_index = Some(stack.len() - 1);
+                stack.extend(
+                    children
+                        .into_iter()
+                        // Reverse so that we pop them off the stack in order.
+                        .rev()
+                        .map(|c| StackEntry {
+                            info: c,
+                            module: wasm_encoder::Module::new(),
+                            sections: c.raw_sections.iter(),
+                            parent_index,
+                            children: c.modules.iter(),
+                            module_section: None,
+                            children_remaining: 0,
+                        }),
+                );
+            }
+
+            // End of the current module: if this is the root, return the
+            // instrumented module, otherwise add it as an entry in its parent's
+            // module section.
+            None => {
+                let entry = stack.pop().unwrap();
+                assert!(entry.module_section.is_none());
+                assert_eq!(entry.children_remaining, 0);
+
+                if entry.info.is_root() {
+                    assert!(stack.is_empty());
+                    return entry.module.finish();
+                }
+
+                let parent = &mut stack[entry.parent_index.unwrap()];
+                parent
+                    .module_section
+                    .as_mut()
+                    .unwrap()
+                    .module(&entry.module);
+
+                assert!(parent.children_remaining > 0);
+                parent.children_remaining -= 1;
+
+                if parent.children_remaining == 0 {
+                    let module_section = parent.module_section.take().unwrap();
+                    parent.module.section(&module_section);
+                }
+            }
+
+            // All other sections don't need instrumentation and can be copied
+            // over directly.
+            Some(section) => {
+                stack.top_mut().module.section(section);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,8 +302,8 @@ impl Wizer {
         // Make sure we're given valid Wasm from the get go.
         self.wasm_validate(&wasm)?;
 
-        let info = parse::parse(wasm)?;
-        let wasm = instrument::instrument(&info);
+        let cx = parse::parse(wasm)?;
+        let wasm = instrument::instrument(&cx);
 
         if cfg!(debug_assertions) {
             if let Err(error) = self.wasm_validate(&wasm) {
@@ -320,7 +320,7 @@ impl Wizer {
 
         let instance = self.initialize(&store, &module)?;
         let snapshot = snapshot::snapshot(&store, &instance);
-        let initialized_wasm = self.rewrite(&snapshot, &info, &renames);
+        let initialized_wasm = self.rewrite(&cx, &snapshot, &renames);
 
         if cfg!(debug_assertions) {
             if let Err(error) = self.wasm_validate(&initialized_wasm) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,11 @@
 
 #![deny(missing_docs)]
 
+#[cfg(fuzzing)]
+pub mod dummy;
+#[cfg(not(fuzzing))]
 mod dummy;
+
 mod info;
 mod instrument;
 mod parse;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -41,7 +41,7 @@ pub(crate) fn parse<'a>(full_wasm: &'a [u8]) -> anyhow::Result<ModuleInfo<'a>> {
 
         use wasmparser::Payload::*;
         match payload {
-            Version { .. } => continue,
+            Version { .. } => {}
             TypeSection(types) => type_section(&mut stack, full_wasm, types)?,
             ImportSection(imports) => import_section(&mut stack, full_wasm, imports)?,
             AliasSection(aliases) => alias_section(&mut stack, full_wasm, aliases)?,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -34,7 +34,7 @@ pub(crate) fn parse<'a>(full_wasm: &'a [u8]) -> anyhow::Result<ModuleInfo<'a>> {
             .parse(wasm, true)
             .context("failed to parse Wasm")?
         {
-            wasmparser::Chunk::NeedMoreData(_) => anyhow::bail!("invalid Wasm module"),
+            wasmparser::Chunk::NeedMoreData(_) => unreachable!(),
             wasmparser::Chunk::Parsed { payload, consumed } => (payload, consumed),
         };
         wasm = &wasm[consumed..];

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,566 @@
+use crate::info::ModuleInfo;
+use crate::stack_ext::StackExt;
+use anyhow::{Context, Result};
+use std::convert::TryFrom;
+use wasm_encoder::SectionId;
+use wasmparser::{SectionReader, SectionWithLimitedItems};
+
+/// Parse the given Wasm bytes into a `ModuleInfo` tree.
+pub(crate) fn parse<'a>(full_wasm: &'a [u8]) -> anyhow::Result<ModuleInfo<'a>> {
+    log::debug!("Parsing the input Wasm");
+
+    // The wasm we are currently parsing. This is advanced as the parser
+    // consumes input.
+    let mut wasm = full_wasm;
+
+    // The counter for making unique-within-the-whole-bundle module identifiers
+    // (i.e. the module's pre-order traversal index).
+    let mut id_counter = 0;
+
+    // The stack of module infos we are parsing. As we visit inner modules
+    // during parsing, we push new entries, and when we finish processing them,
+    // we pop them.
+    let mut stack = vec![ModuleInfo::for_root()];
+
+    // Stack of parsers for each module we are parsing. Has a parallel structure
+    // to `stack`.
+    let mut parsers = vec![wasmparser::Parser::new(0)];
+
+    loop {
+        assert_eq!(stack.len(), parsers.len());
+
+        let (payload, consumed) = match parsers
+            .top_mut()
+            .parse(wasm, true)
+            .context("failed to parse Wasm")?
+        {
+            wasmparser::Chunk::NeedMoreData(_) => anyhow::bail!("invalid Wasm module"),
+            wasmparser::Chunk::Parsed { payload, consumed } => (payload, consumed),
+        };
+        wasm = &wasm[consumed..];
+
+        use wasmparser::Payload::*;
+        match payload {
+            Version { .. } => continue,
+            TypeSection(types) => type_section(&mut stack, full_wasm, types)?,
+            ImportSection(imports) => import_section(&mut stack, full_wasm, imports)?,
+            AliasSection(aliases) => alias_section(&mut stack, full_wasm, aliases)?,
+            InstanceSection(instances) => instance_section(&mut stack, full_wasm, instances)?,
+            ModuleSectionStart {
+                range,
+                size: _,
+                count: _,
+            } => {
+                let info = stack.top_mut();
+                info.add_raw_section(SectionId::Module, range, full_wasm);
+            }
+            ModuleSectionEntry { parser, range: _ } => {
+                id_counter += 1;
+                stack.push(ModuleInfo::for_inner(id_counter));
+                parsers.push(parser);
+            }
+            FunctionSection(funcs) => function_section(&mut stack, full_wasm, funcs)?,
+            TableSection(tables) => table_section(&mut stack, full_wasm, tables)?,
+            MemorySection(mems) => memory_section(&mut stack, full_wasm, mems)?,
+            GlobalSection(globals) => global_section(&mut stack, full_wasm, globals)?,
+            ExportSection(exports) => export_section(&mut stack, full_wasm, exports)?,
+            StartSection { func: _, range } => {
+                stack
+                    .top_mut()
+                    .add_raw_section(SectionId::Start, range, full_wasm)
+            }
+            ElementSection(elems) => {
+                stack
+                    .top_mut()
+                    .add_raw_section(SectionId::Element, elems.range(), full_wasm)
+            }
+            DataCountSection { .. } => unreachable!("validation rejects bulk memory"),
+            DataSection(data) => {
+                stack
+                    .top_mut()
+                    .add_raw_section(SectionId::Data, data.range(), full_wasm)
+            }
+            CustomSection { range, .. } => {
+                stack
+                    .top_mut()
+                    .add_raw_section(SectionId::Custom, range, full_wasm)
+            }
+            CodeSectionStart {
+                range,
+                count: _,
+                size,
+            } => {
+                parsers.top_mut().skip_section();
+                wasm = &wasm[usize::try_from(size).unwrap()..];
+                stack
+                    .top_mut()
+                    .add_raw_section(SectionId::Code, range, full_wasm)
+            }
+            CodeSectionEntry(_) => unreachable!(),
+            UnknownSection { .. } => anyhow::bail!("unknown section"),
+            EventSection(_) => anyhow::bail!("exceptions are not supported yet"),
+            End => {
+                let info = stack.pop().unwrap();
+                parsers.pop();
+
+                // If we finished parsing the root Wasm module, then we're done.
+                if info.is_root() {
+                    assert!(stack.is_empty());
+                    assert!(parsers.is_empty());
+                    return Ok(info);
+                }
+
+                // Otherwise, we need to add this module to its parent's module
+                // section.
+                let parent = stack.top_mut();
+                parent.modules.push(info);
+            }
+        }
+    }
+}
+
+fn type_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut types: wasmparser::TypeSectionReader<'a>,
+) -> anyhow::Result<()> {
+    let info = stack.top_mut();
+    info.add_raw_section(SectionId::Type, types.range(), full_wasm);
+
+    // Parse out types, as we will need them later when processing
+    // instance imports.
+    let count = usize::try_from(types.get_count()).unwrap();
+    info.types.reserve(count);
+    for _ in 0..count {
+        let ty = types.read()?;
+        match ty {
+            wasmparser::TypeDef::Func(_) | wasmparser::TypeDef::Instance(_) => {
+                info.types.push(ty);
+            }
+            wasmparser::TypeDef::Module(_) => Err(anyhow::anyhow!(
+                "wizer does not support importing or exporting modules"
+            )
+            .context("module types are not supported"))?,
+        }
+    }
+
+    Ok(())
+}
+
+fn import_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut imports: wasmparser::ImportSectionReader<'a>,
+) -> anyhow::Result<()> {
+    stack
+        .top_mut()
+        .add_raw_section(SectionId::Import, imports.range(), full_wasm);
+
+    let mut instance_import_count = 0;
+
+    // Check that we can properly handle all imports.
+    let count = imports.get_count();
+    for _ in 0..count {
+        let imp = imports.read()?;
+        stack.top_mut().imports.push(imp);
+        check_import_type(&stack.top().types, stack.top().is_root(), &imp.ty)?;
+
+        if imp.module.starts_with("__wizer_")
+            || imp.field.map_or(false, |f| f.starts_with("__wizer_"))
+        {
+            anyhow::bail!(
+                "input Wasm module already imports entities named with the `__wizer_*` prefix"
+            );
+        }
+
+        // Add the import to the appropriate index space for our current module.
+        match imp.ty {
+            wasmparser::ImportSectionEntryType::Memory(ty) => {
+                assert!(stack.top().defined_memories_index.is_none());
+                stack.top_mut().memories.push(ty);
+            }
+            wasmparser::ImportSectionEntryType::Global(ty) => {
+                assert!(stack.top().defined_globals_index.is_none());
+                stack.top_mut().globals.push(ty);
+            }
+            wasmparser::ImportSectionEntryType::Instance(ty_idx) => {
+                let info = stack.top_mut();
+                let ty = match &info.types[usize::try_from(ty_idx).unwrap()] {
+                    wasmparser::TypeDef::Instance(ty) => ty.clone(),
+                    _ => unreachable!(),
+                };
+                info.instances.push(ty);
+                instance_import_count += 1;
+            }
+            wasmparser::ImportSectionEntryType::Function(func_ty) => {
+                stack.top_mut().functions.push(func_ty);
+            }
+            wasmparser::ImportSectionEntryType::Table(ty) => {
+                stack.top_mut().tables.push(ty);
+            }
+
+            wasmparser::ImportSectionEntryType::Module(_) => {
+                unreachable!("should have been rejected by `check_import_type`")
+            }
+            wasmparser::ImportSectionEntryType::Event(_) => {
+                unreachable!("should have been rejected by validation")
+            }
+        }
+    }
+
+    stack
+        .top_mut()
+        .instance_import_counts
+        .push(instance_import_count);
+
+    Ok(())
+}
+
+fn check_import_type(
+    types: &[wasmparser::TypeDef],
+    is_root: bool,
+    ty: &wasmparser::ImportSectionEntryType,
+) -> Result<()> {
+    match ty {
+        wasmparser::ImportSectionEntryType::Module(_) => {
+            // We need to disallow module imports, even within nested modules
+            // that only ever have other nested modules supplied as
+            // arguments. Two different modules could be supplied for two
+            // different instantiations of the module-importing module, but then
+            // after we export all modules' globals in our instrumentation
+            // phase, those two different module arguments could become
+            // type-incompatible with each other:
+            //
+            // ```
+            // (module
+            //
+            //   ;; Module A exports and `f` function. Internally it has
+            //   ;; one global.
+            //   (module $A
+            //     (global $g ...)
+            //     (func (export "f") ...))
+            //
+            //   ;; Module B has an identical interface as A. Internally
+            //   ;; it has two globals.
+            //   (module $B
+            //     (global $g ...)
+            //     (global $h ...)
+            //     (func (export "f") ...))
+            //
+            //   ;; Module C imports any module that exports an `f`
+            //   ;; function. It instantiates this imported module.
+            //   (module $C
+            //     (import "env" "module"
+            //       (module (export "f" (func)))
+            //     (instance 0)))
+            //
+            //   ;; C is instantiated with both A and B.
+            //   (instance $C (import "env" "module" $A))
+            //   (instance $C (import "env" "module" $B))
+            // )
+            // ```
+            //
+            // After this instrumentation pass, we need to make module C
+            // transitively export all of the globals from its inner
+            // instances. Which means that the module type used in the module
+            // import needs to specify how many modules are in the imported
+            // module, but in our two instantiations, we have two different
+            // numbers of globals defined in each module! The only way to
+            // resolve this would be to duplicate and specialize module C for
+            // each instantiation, which we don't want to do for complexity and
+            // code size reasons.
+            anyhow::bail!("imported modules are not supported by Wizer")
+        }
+        wasmparser::ImportSectionEntryType::Instance(inst_ty_index) => {
+            // We allow importing instances that only export things that are
+            // acceptable imports. This is equivalent to a two-layer import.
+            match &types[usize::try_from(*inst_ty_index).unwrap()] {
+                wasmparser::TypeDef::Instance(inst_ty) => {
+                    for e in inst_ty.exports.iter() {
+                        check_import_type(&types, is_root, &e.ty)?;
+                    }
+                    Ok(())
+                }
+                _ => unreachable!(),
+            }
+        }
+        wasmparser::ImportSectionEntryType::Memory(mem_ty) => match mem_ty {
+            wasmparser::MemoryType::M32 { limits: _, shared } => {
+                anyhow::ensure!(!shared, "shared memories are not supported by Wizer yet");
+                anyhow::ensure!(
+                    !is_root,
+                    "memory imports are not allowed in the root Wasm module"
+                );
+                Ok(())
+            }
+            wasmparser::MemoryType::M64 { .. } => {
+                anyhow::bail!("the memory64 proposal is not supported by Wizer yet")
+            }
+        },
+        wasmparser::ImportSectionEntryType::Event(_) => {
+            unreachable!("validation should have rejected the exceptions proposal")
+        }
+        wasmparser::ImportSectionEntryType::Function(_) => Ok(()),
+        wasmparser::ImportSectionEntryType::Table(_)
+        | wasmparser::ImportSectionEntryType::Global(_) => {
+            anyhow::ensure!(
+                !is_root,
+                "table and global imports are not allowed in the root Wasm module"
+            );
+            Ok(())
+        }
+    }
+}
+
+fn alias_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut aliases: wasmparser::AliasSectionReader<'a>,
+) -> anyhow::Result<()> {
+    stack
+        .top_mut()
+        .add_raw_section(SectionId::Alias, aliases.range(), full_wasm);
+
+    // Clone any aliases over into this module's index spaces.
+    for _ in 0..aliases.get_count() {
+        let alias = aliases.read()?;
+        match &alias {
+            wasmparser::Alias::OuterType {
+                relative_depth,
+                index,
+            } => {
+                let relative_depth = usize::try_from(*relative_depth).unwrap();
+                let index = usize::try_from(*index).unwrap();
+                // NB: `- 2` rather than `- 1` because
+                // `relative_depth=0` means this module's immediate
+                // parent, not this module itself.
+                let ty = stack[stack.len() - 2 - relative_depth].types[index].clone();
+                stack.top_mut().types.push(ty);
+            }
+            wasmparser::Alias::OuterModule {
+                relative_depth,
+                index,
+            } => {
+                let relative_depth = usize::try_from(*relative_depth).unwrap();
+                let index = usize::try_from(*index).unwrap();
+                // Ditto regarding `- 2`.
+                let module = stack[stack.len() - 2 - relative_depth].modules[index].clone();
+                stack.top_mut().modules.push(module);
+            }
+            wasmparser::Alias::InstanceExport {
+                instance,
+                kind,
+                export,
+            } => match kind {
+                wasmparser::ExternalKind::Module => {
+                    anyhow::bail!("exported modules are not supported yet")
+                }
+                wasmparser::ExternalKind::Instance => {
+                    let info = stack.top_mut();
+                    let inst_ty_idx = match info.instance_export(*instance, export) {
+                        Some(wasmparser::ImportSectionEntryType::Instance(i)) => i,
+                        _ => unreachable!(),
+                    };
+                    let inst_ty = match &info.types[usize::try_from(inst_ty_idx).unwrap()] {
+                        wasmparser::TypeDef::Instance(ty) => ty.clone(),
+                        _ => unreachable!(),
+                    };
+                    info.instances.push(inst_ty);
+                }
+                wasmparser::ExternalKind::Function => {
+                    let info = stack.top_mut();
+                    let func_ty_idx = match info.instance_export(*instance, export) {
+                        Some(wasmparser::ImportSectionEntryType::Function(i)) => i,
+                        _ => unreachable!(),
+                    };
+                    info.functions.push(func_ty_idx);
+                }
+                wasmparser::ExternalKind::Table => {
+                    let info = stack.top_mut();
+                    let table_ty = match info.instance_export(*instance, export) {
+                        Some(wasmparser::ImportSectionEntryType::Table(ty)) => ty,
+                        _ => unreachable!(),
+                    };
+                    info.tables.push(table_ty);
+                }
+                wasmparser::ExternalKind::Memory => {
+                    let info = stack.top_mut();
+                    assert!(info.defined_memories_index.is_none());
+                    let ty = match info.instance_export(*instance, export) {
+                        Some(wasmparser::ImportSectionEntryType::Memory(ty)) => ty,
+                        _ => unreachable!(),
+                    };
+                    info.memories.push(ty);
+                }
+                wasmparser::ExternalKind::Global => {
+                    let info = stack.top_mut();
+                    assert!(info.defined_globals_index.is_none());
+                    let ty = match info.instance_export(*instance, export) {
+                        Some(wasmparser::ImportSectionEntryType::Global(ty)) => ty,
+                        _ => unreachable!(),
+                    };
+                    info.globals.push(ty);
+                }
+                wasmparser::ExternalKind::Event => {
+                    unreachable!("validation should reject the exceptions proposal")
+                }
+                wasmparser::ExternalKind::Type => unreachable!("can't export types"),
+            },
+        }
+        stack.top_mut().aliases.push(alias);
+    }
+
+    Ok(())
+}
+
+fn instance_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut instances: wasmparser::InstanceSectionReader<'a>,
+) -> anyhow::Result<()> {
+    stack
+        .top_mut()
+        .add_raw_section(SectionId::Instance, instances.range(), full_wasm);
+
+    // Record the instantiations made in this module, and which modules were
+    // instantiated.
+    let info = stack.top_mut();
+    for _ in 0..instances.get_count() {
+        let inst = instances.read()?;
+        let module_index: usize = usize::try_from(inst.module()).unwrap();
+        let module = &info.modules[module_index];
+        let module_id = module.id;
+        let inst_ty = module.instance_type();
+
+        let mut import_args_reader = inst.args()?;
+        let import_args_count = usize::try_from(import_args_reader.get_count()).unwrap();
+        let mut import_args = Vec::with_capacity(import_args_count);
+        for _ in 0..import_args_count {
+            import_args.push(import_args_reader.read()?);
+        }
+
+        info.instantiations.insert(
+            u32::try_from(info.instances.len()).unwrap(),
+            (module_id, import_args),
+        );
+        info.instances.push(inst_ty);
+    }
+
+    Ok(())
+}
+
+fn function_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut funcs: wasmparser::FunctionSectionReader<'a>,
+) -> anyhow::Result<()> {
+    stack
+        .top_mut()
+        .add_raw_section(SectionId::Function, funcs.range(), full_wasm);
+
+    let info = stack.top_mut();
+    let count = usize::try_from(funcs.get_count()).unwrap();
+    info.functions.reserve(count);
+    for _ in 0..count {
+        let ty = funcs.read()?;
+        info.functions.push(ty);
+    }
+    Ok(())
+}
+
+fn table_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut tables: wasmparser::TableSectionReader<'a>,
+) -> anyhow::Result<()> {
+    stack
+        .top_mut()
+        .add_raw_section(SectionId::Table, tables.range(), full_wasm);
+
+    let info = stack.top_mut();
+    let count = usize::try_from(tables.get_count()).unwrap();
+    info.tables.reserve(count);
+    for _ in 0..count {
+        info.tables.push(tables.read()?);
+    }
+    Ok(())
+}
+
+fn memory_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut mems: wasmparser::MemorySectionReader<'a>,
+) -> anyhow::Result<()> {
+    let info = stack.top_mut();
+    info.add_raw_section(SectionId::Memory, mems.range(), full_wasm);
+
+    assert!(info.defined_memories_index.is_none());
+    info.defined_memories_index = Some(u32::try_from(info.memories.len()).unwrap());
+
+    let count = usize::try_from(mems.get_count()).unwrap();
+    info.memories.reserve(count);
+    for _ in 0..count {
+        let m = mems.read()?;
+        info.memories.push(m);
+    }
+    Ok(())
+}
+
+fn global_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut globals: wasmparser::GlobalSectionReader<'a>,
+) -> anyhow::Result<()> {
+    let info = stack.top_mut();
+    info.add_raw_section(SectionId::Global, globals.range(), full_wasm);
+
+    assert!(info.defined_globals_index.is_none());
+    info.defined_globals_index = Some(u32::try_from(info.globals.len()).unwrap());
+
+    let count = usize::try_from(globals.get_count()).unwrap();
+    info.globals.reserve(count);
+    for _ in 0..count {
+        let g = globals.read()?;
+        info.globals.push(g.ty);
+    }
+
+    Ok(())
+}
+
+fn export_section<'a>(
+    stack: &mut Vec<ModuleInfo<'a>>,
+    full_wasm: &'a [u8],
+    mut exports: wasmparser::ExportSectionReader<'a>,
+) -> anyhow::Result<()> {
+    stack
+        .top_mut()
+        .add_raw_section(SectionId::Export, exports.range(), full_wasm);
+
+    let info = stack.top_mut();
+    for _ in 0..exports.get_count() {
+        let export = exports.read()?;
+
+        if export.field.starts_with("__wizer_") {
+            anyhow::bail!(
+                "input Wasm module already exports entities named with the `__wizer_*` prefix"
+            );
+        }
+
+        match export.kind {
+            wasmparser::ExternalKind::Module => {
+                anyhow::bail!("Wizer does not support importing and exporting modules")
+            }
+            wasmparser::ExternalKind::Type | wasmparser::ExternalKind::Event => {
+                unreachable!("checked in validation")
+            }
+            wasmparser::ExternalKind::Function
+            | wasmparser::ExternalKind::Table
+            | wasmparser::ExternalKind::Memory
+            | wasmparser::ExternalKind::Global
+            | wasmparser::ExternalKind::Instance => {
+                info.exports.push(export.clone());
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -137,6 +137,168 @@ impl Wizer {
     ) -> Vec<u8> {
         log::debug!("Rewriting input Wasm to pre-initialized state");
 
+        if cx.uses_module_linking() {
+            self.rewrite_with_module_linking(cx, snapshot, renames)
+        } else {
+            self.rewrite_without_module_linking(cx, snapshot, renames)
+        }
+    }
+
+    /// Rewrite a root Wasm module that has no children and doesn't use module
+    /// linking at all.
+    fn rewrite_without_module_linking(
+        &self,
+        cx: &ModuleContext,
+        snapshot: &Snapshot,
+        renames: &FuncRenames,
+    ) -> Vec<u8> {
+        assert!(snapshot.instantiations.is_empty());
+
+        let mut encoder = wasm_encoder::Module::new();
+        let module = cx.root();
+
+        // Encode the initialized data segments from the snapshot rather
+        // than the original, uninitialized data segments.
+        let mut data_section = if snapshot.data_segments.is_empty() {
+            None
+        } else {
+            let mut data_section = wasm_encoder::DataSection::new();
+            for seg in &snapshot.data_segments {
+                data_section.active(
+                    seg.memory_index,
+                    wasm_encoder::Instruction::I32Const(seg.offset as i32),
+                    seg.data.iter().copied(),
+                );
+            }
+            Some(data_section)
+        };
+
+        // There are multiple places were we potentially need to check whether
+        // we've added the data section already and if we haven't yet, then do
+        // so. For example, the original Wasm might not have a data section at
+        // all, and so we have to potentially add it at the end of iterating
+        // over the original sections. This closure encapsulates all that
+        // add-it-if-we-haven't-already logic in one place.
+        let mut add_data_section = |module: &mut wasm_encoder::Module| {
+            if let Some(data_section) = data_section.take() {
+                module.section(&data_section);
+            }
+        };
+
+        for section in module.raw_sections(cx) {
+            match section {
+                // Some tools expect the name custom section to come last, even
+                // though custom sections are allowed in any order. Therefore,
+                // make sure we've added our data section by now.
+                s if is_name_section(s) => {
+                    add_data_section(&mut encoder);
+                    encoder.section(s);
+                }
+
+                // For the memory section, we update the minimum size of each
+                // defined memory to the snapshot's initialized size for that
+                // memory.
+                s if s.id == SectionId::Memory.into() => {
+                    let mut memories = wasm_encoder::MemorySection::new();
+                    assert_eq!(module.defined_memories_len(cx), snapshot.memory_mins.len());
+                    for ((_, mem), new_min) in module
+                        .defined_memories(cx)
+                        .zip(snapshot.memory_mins.iter().copied())
+                    {
+                        let mut mem = translate::memory_type(mem);
+                        mem.limits.min = new_min;
+                        memories.memory(mem);
+                    }
+                    encoder.section(&memories);
+                }
+
+                // Encode the initialized global values from the snapshot,
+                // rather than the original values.
+                s if s.id == SectionId::Global.into() => {
+                    let mut globals = wasm_encoder::GlobalSection::new();
+                    for ((_, glob_ty), val) in
+                        module.defined_globals(cx).zip(snapshot.globals.iter())
+                    {
+                        let glob_ty = translate::global_type(glob_ty);
+                        globals.global(
+                            glob_ty,
+                            match val {
+                                wasmtime::Val::I32(x) => wasm_encoder::Instruction::I32Const(*x),
+                                wasmtime::Val::I64(x) => wasm_encoder::Instruction::I64Const(*x),
+                                wasmtime::Val::F32(x) => {
+                                    wasm_encoder::Instruction::F32Const(f32::from_bits(*x))
+                                }
+                                wasmtime::Val::F64(x) => {
+                                    wasm_encoder::Instruction::F64Const(f64::from_bits(*x))
+                                }
+                                _ => unreachable!(),
+                            },
+                        );
+                    }
+                    encoder.section(&globals);
+                }
+
+                // Remove the initialization function's export and perform any
+                // requested renames.
+                s if s.id == SectionId::Export.into() => {
+                    let mut exports = wasm_encoder::ExportSection::new();
+                    for export in module.exports(cx) {
+                        if export.field == self.init_func {
+                            continue;
+                        }
+
+                        if !renames.rename_src_to_dst.contains_key(export.field)
+                            && renames.rename_dsts.contains(export.field)
+                        {
+                            // A rename overwrites this export, and it is not
+                            // renamed to another export, so skip it.
+                            continue;
+                        }
+
+                        let field = renames
+                            .rename_src_to_dst
+                            .get(export.field)
+                            .map_or(export.field, |f| f.as_str());
+
+                        let export = translate::export(export.kind, export.index);
+                        exports.export(field, export);
+                    }
+                    encoder.section(&exports);
+                }
+
+                // Skip the `start` function -- it's already been run!
+                s if s.id == SectionId::Start.into() => {
+                    continue;
+                }
+
+                s if s.id == SectionId::Data.into() => {
+                    // TODO: supporting bulk memory will require copying over
+                    // any passive and declared segments.
+                    add_data_section(&mut encoder);
+                }
+
+                s if s.id == SectionId::Module.into() => unreachable!(),
+                s if s.id == SectionId::Instance.into() => unreachable!(),
+                s if s.id == SectionId::Alias.into() => unreachable!(),
+
+                s => {
+                    encoder.section(s);
+                }
+            }
+        }
+
+        // Make sure that we've added our data section to the module.
+        add_data_section(&mut encoder);
+        encoder.finish()
+    }
+
+    /// Rewrite a module linking bundle.
+    fn rewrite_with_module_linking(
+        &self,
+        cx: &ModuleContext<'_>,
+        snapshot: &Snapshot,
+        renames: &FuncRenames,
+    ) -> Vec<u8> {
         let root_info = cx.root();
         let mut root = wasm_encoder::Module::new();
 
@@ -144,15 +306,10 @@ impl Wizer {
         root.section(&types);
 
         let (code_modules, num_code_modules) = rewrite_code_modules(cx);
-        // Only add the module section if there are multiple code modules,
-        // so that we avoid introducing the module section when module
-        // linking isn't in use.
-        if num_code_modules > 0 {
-            root.section(&code_modules);
+        root.section(&code_modules);
 
-            let state_modules = rewrite_state_modules(cx, &snapshot.instantiations);
-            root.section(&state_modules);
-        }
+        let state_modules = rewrite_state_modules(cx, &snapshot.instantiations);
+        root.section(&state_modules);
 
         self.rewrite_root(cx, &mut root, snapshot, renames, num_code_modules);
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -149,7 +149,7 @@ impl Wizer {
             root.section(&code_modules);
 
             let state_modules =
-                rewrite_state_modules(info, &id_to_module_info, &snapshot.instantiations, 0);
+                rewrite_state_modules(info, &id_to_module_info, &snapshot.instantiations);
             root.section(&state_modules);
         }
 
@@ -804,15 +804,13 @@ fn rewrite_state_modules(
     info: &ModuleInfo,
     id_to_module_info: &Vec<&ModuleInfo>,
     snapshots: &[Snapshot],
-    depth: u32,
 ) -> wasm_encoder::ModuleSection {
     let mut modules = wasm_encoder::ModuleSection::new();
 
     assert_eq!(snapshots.len(), info.instantiations.len());
     for (snapshot, (module_id, _)) in snapshots.iter().zip(info.instantiations.values()) {
         let module_info = &id_to_module_info[usize::try_from(*module_id).unwrap()];
-        let state_module =
-            rewrite_one_state_module(module_info, id_to_module_info, snapshot, depth);
+        let state_module = rewrite_one_state_module(module_info, id_to_module_info, snapshot, 0);
         modules.module(&state_module);
     }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,0 +1,1092 @@
+//! Final rewrite pass.
+
+mod renumbering;
+
+use crate::{info::ModuleInfo, snapshot::Snapshot, translate, FuncRenames, Wizer};
+use renumbering::Renumbering;
+use std::{convert::TryFrom, iter};
+use wasm_encoder::SectionId;
+
+impl Wizer {
+    /// Given the initialized snapshot, rewrite the Wasm so that it is already
+    /// initialized.
+    ///
+    /// ## Code Shape
+    ///
+    /// With module linking, we rewrite each nested module into a *code module*
+    /// that doesn't define any internal state (i.e. memories, globals, and
+    /// nested instances) and imports a *state instance* that exports all of
+    /// these things instead. For each instantiation of a nested module, we have
+    /// a *state module* that defines the already-initialized state for that
+    /// instantiation, we instantiate that state module to create one such state
+    /// instance, and then use this as an import argument in the instantiation
+    /// of the original code module. This way, we do not duplicate shared code
+    /// bodies across multiple instantiations of the same module.
+    ///
+    /// Note that the root module is not split into a code module and state
+    /// instance. We can, essentially, assume that there is only one instance of
+    /// the root module, and rewrite it in place, without factoring the state
+    /// out into a separate instance. This is because the root is not allowed to
+    /// import any external state, so even if it were instantiated multiple
+    /// times, it would still end up in the same place anyways. (This is kinda
+    /// the whole reason why Wizer works at all.)
+    ///
+    /// For example, given this input Wasm module:
+    ///
+    /// ```wat
+    /// (module $A
+    ///   (module $B
+    ///     (memory $B_mem)
+    ///     (global $B_glob (mut i32))
+    ///     (func (export "f") ...)
+    ///   )
+    ///
+    ///   (instance $x (instantiate $B))
+    ///   (instance $y (instantiate $B))
+    ///
+    ///   (memory $A_mem)
+    ///   (global $A_glob (mut i32))
+    ///
+    ///   (func (export "g") ...)
+    /// )
+    /// ```
+    ///
+    /// and some post-initialization state, this rewrite pass will produce the
+    /// following pre-initialized module:
+    ///
+    /// ```wat
+    /// (module $A
+    ///   (module $B
+    ///     ;; Locally defined state is replaced by a state instance import.
+    ///     (import "__wizer_state"
+    ///       (instance
+    ///         (export "__wizer_memory_0" (memory $B_mem))
+    ///         (export "__wizer_global_0" (global $B_glob (mut i32)))
+    ///       )
+    ///     )
+    ///     (func (export "f") ...)
+    ///   )
+    ///
+    ///   ;; Instantiations are replaced with specialized state modules that get
+    ///   ;; instantiated exactly once to produce state instances, and finally
+    ///   ;; the original instantiations are rewritten into instantiations of
+    ///   ;; the corresponding code module with the state instance as an import
+    ///   ;; argument.
+    ///
+    ///   ;; State module for `$x`.
+    ///   (module $x_state_module
+    ///     (memory (export "__wizer_memory_0") (memory))
+    ///     ;; Data segments to initialize the memory based on our snapshot
+    ///     ;; would go here...
+    ///
+    ///     (global (export "__wizer_global_0")
+    ///       (global (mut i32) (i32.const (; ...snapshot's initialized value goes here... ;)))
+    ///     )
+    ///   )
+    ///
+    ///   ;; State instance for `$x`.
+    ///   (instance $x_state (instantiate $x_state_module))
+    ///
+    ///   ;; The instantiation of `$x` is now rewritten to use our state
+    ///   ;; instance.
+    ///   (instance $x (instantiate $B (import "__wizer_state" $x_state)))
+    ///
+    ///   ;; Same goes for the `$y` instantiation.
+    ///   (module $y_state_module
+    ///     (memory (export "__wizer_memory_0") (memory))
+    ///     ;; Data segments...
+    ///     (global (export "__wizer_global_0")
+    ///       (global (mut i32) (i32.const (; ...snapshot's initialized value goes here... ;)))
+    ///     )
+    ///   )
+    ///   (instance $y_state (instantiate $y_state_module))
+    ///   (instance $y (instantiate $B (import "__wizer_state" $y_state)))
+    ///
+    ///   (memory $A_mem)
+    ///   (global $A_glob (mut i32))
+    /// )
+    /// ```
+    ///
+    /// ## Implementation
+    ///
+    /// To implement this transformation, we first do a pre-order walk of the
+    /// module tree and emit the code modules as a flat sequence. Why a flat
+    /// sequence? The code modules cannot contain nested instantiations, because
+    /// nested instantiations are state that is not necessarily shared across
+    /// all instantiations of the outer module. And if we are already lifting
+    /// out nested instantiations, we need to also make nested modules available
+    /// for those lifted instantiations, and the easiest way to do that is to
+    /// flatten the code module tree (as opposed to re-exporting the nested
+    /// modules under well-known symbols). The pre-order traversal ensures that
+    /// the `ModuleInfo::id` we assigned during the instrumentation phase
+    /// matches the module's place in the index space. The state modules,
+    /// however, remain a nested tree, and we emit them in a traversal of the
+    /// `Snapshot` instance tree. This is safe because, unlike code modules,
+    /// each state module is only instantiated exactly once. The instantiations'
+    /// references to nested modules become outer aliases pointing to the
+    /// module's position in the parent's flat sequence of nested modules.
+    pub(crate) fn rewrite(
+        &self,
+        snapshot: &Snapshot,
+        info: &ModuleInfo,
+        renames: &FuncRenames,
+    ) -> Vec<u8> {
+        log::debug!("Rewriting input Wasm to pre-initialized state");
+
+        let mut root = wasm_encoder::Module::new();
+
+        let types = make_complete_type_section(info);
+        root.section(&types);
+
+        let mut id_to_module_info = vec![];
+        make_id_to_module_info(&mut id_to_module_info, info);
+
+        let (code_modules, num_code_modules) = rewrite_code_modules(info, &id_to_module_info);
+        // Only add the module section if there are multiple code modules,
+        // so that we avoid introducing the module section when module
+        // linking isn't in use.
+        if num_code_modules > 0 {
+            root.section(&code_modules);
+
+            let state_modules =
+                rewrite_state_modules(info, &id_to_module_info, &snapshot.instantiations, 0);
+            root.section(&state_modules);
+        }
+
+        self.rewrite_root(&mut root, info, snapshot, renames, num_code_modules);
+
+        root.finish()
+    }
+
+    fn rewrite_root(
+        &self,
+        root: &mut wasm_encoder::Module,
+        root_info: &ModuleInfo,
+        snapshot: &Snapshot,
+        renames: &FuncRenames,
+        num_code_modules: u32,
+    ) {
+        // Encode the initialized data segments from the snapshot rather
+        // than the original, uninitialized data segments.
+        let mut data_section = if snapshot.data_segments.is_empty() {
+            None
+        } else {
+            let mut data_section = wasm_encoder::DataSection::new();
+            for seg in &snapshot.data_segments {
+                data_section.active(
+                    seg.memory_index,
+                    wasm_encoder::Instruction::I32Const(seg.offset as i32),
+                    seg.data.iter().copied(),
+                );
+            }
+            Some(data_section)
+        };
+
+        // There are multiple places were we potentially need to check whether
+        // we've added the data section already and if we haven't yet, then do
+        // so. For example, the original Wasm might not have a data section at
+        // all, and so we have to potentially add it at the end of iterating
+        // over the original sections. This closure encapsulates all that
+        // add-it-if-we-haven't-already logic in one place.
+        let mut add_data_section = |module: &mut wasm_encoder::Module| {
+            if let Some(data_section) = data_section.take() {
+                module.section(&data_section);
+            }
+        };
+
+        // A map from the original Wasm's instance numbering to the newly rewritten
+        // instance numbering.
+        let mut instance_renumbering = Renumbering::default();
+
+        let mut instance_import_counts = root_info.instance_import_counts.iter().copied();
+        let mut instantiations = root_info.instantiations.values().enumerate();
+        let mut aliases = root_info.aliases.iter();
+
+        for section in &root_info.raw_sections {
+            match section {
+                // Some tools expect the name custom section to come last, even
+                // though custom sections are allowed in any order. Therefore,
+                // make sure we've added our data section by now.
+                s if is_name_section(s) => {
+                    add_data_section(root);
+                    root.section(s);
+                }
+
+                s if s.id == SectionId::Custom.into() => {
+                    root.section(s);
+                }
+
+                // These were already added in `make_complete_type_section`.
+                s if s.id == SectionId::Type.into() => {
+                    continue;
+                }
+
+                // These were already taken care of in `rewrite_code_modules`.
+                s if s.id == SectionId::Module.into() => {
+                    continue;
+                }
+
+                // Import sections are just copied over, but we additionally
+                // must make sure that our count of how many instances are
+                // currently in this module's instance export space and map from
+                // old instance numbering to new instance numbering are
+                // correctly updated for any instances that were imported in
+                // this section.
+                s if s.id == SectionId::Import.into() => {
+                    root.section(s);
+
+                    let instance_import_count = instance_import_counts.next().unwrap();
+                    for _ in 0..instance_import_count {
+                        instance_renumbering.add_import();
+                    }
+                }
+
+                // Instantiations from the original Wasm become two
+                // instantiations in the rewritten Wasm:
+                //
+                // 1. First, we instantiate the state module for this instance
+                //    to create the rewritten state instance.
+                //
+                // 2. Then, we instantiate this instance's code module, passing
+                //    it the state instance and any other import arguments it
+                //    originally had. This, finally, is the rewritten version of
+                //    the original instance.
+                //
+                // Because there are two instances, where previously there was
+                // one, we are forced to renumber the instance index space.
+                s if s.id == SectionId::Instance.into() => {
+                    let mut instances = wasm_encoder::InstanceSection::new();
+                    let count = wasmparser::InstanceSectionReader::new(s.data, 0)
+                        .unwrap()
+                        .get_count();
+                    for (nth_defined_inst, (module_id, instance_args)) in instantiations
+                        .by_ref()
+                        .take(usize::try_from(count).unwrap())
+                    {
+                        // Instantiate the state module.
+                        let args: Vec<_> = instance_args
+                            .iter()
+                            .map(|arg| {
+                                let mut arg = translate::instance_arg(arg);
+                                if let (_name, wasm_encoder::Export::Instance(ref mut index)) = arg
+                                {
+                                    *index = instance_renumbering.lookup(*index);
+                                }
+                                arg
+                            })
+                            .collect();
+                        instances.instantiate(
+                            num_code_modules + u32::try_from(nth_defined_inst).unwrap(),
+                            args,
+                        );
+                        let state_instance_index = instance_renumbering.define_new();
+
+                        // Instantiate the code module with our state instance
+                        // and the original import arguments.
+                        let args: Vec<_> = iter::once((
+                            "__wizer_state",
+                            wasm_encoder::Export::Instance(state_instance_index),
+                        ))
+                        .chain(instance_args.iter().map(|arg| {
+                            let mut arg = translate::instance_arg(arg);
+                            if let (_name, wasm_encoder::Export::Instance(ref mut index)) = arg {
+                                *index = instance_renumbering.lookup(*index);
+                            }
+                            arg
+                        }))
+                        .collect();
+                        instances.instantiate(module_id - 1, args);
+                        instance_renumbering.define_both();
+                    }
+                    root.section(&instances);
+                }
+
+                // For the alias section, we update instance export aliases to
+                // use the new instance numbering.
+                s if s.id == SectionId::Alias.into() => {
+                    let count = wasmparser::AliasSectionReader::new(s.data, 0)
+                        .unwrap()
+                        .get_count();
+                    let mut section = wasm_encoder::AliasSection::new();
+                    for alias in aliases.by_ref().take(usize::try_from(count).unwrap()) {
+                        match alias {
+                            wasmparser::Alias::InstanceExport {
+                                instance,
+                                kind,
+                                export,
+                            } => {
+                                section.instance_export(
+                                    instance_renumbering.lookup(*instance),
+                                    translate::item_kind(*kind),
+                                    export,
+                                );
+                                // If this brought a new instance into our
+                                // instance index space, update our renumbering
+                                // map.
+                                if let wasmparser::ExternalKind::Instance = kind {
+                                    instance_renumbering.add_alias();
+                                }
+                            }
+                            wasmparser::Alias::OuterType { .. }
+                            | wasmparser::Alias::OuterModule { .. } => {
+                                unreachable!(
+                                    "the root can't alias any outer entities because there are \
+                                     no entities outside the root module"
+                                )
+                            }
+                        }
+                    }
+                    root.section(&section);
+                }
+
+                s if s.id == SectionId::Function.into() => {
+                    root.section(s);
+                }
+
+                s if s.id == SectionId::Table.into() => {
+                    root.section(s);
+                }
+
+                // For the memory section, we update the minimum size of each
+                // defined memory to the snapshot's initialized size for that
+                // memory.
+                s if s.id == SectionId::Memory.into() => {
+                    let mut memories = wasm_encoder::MemorySection::new();
+                    assert_eq!(root_info.defined_memories_len(), snapshot.memory_mins.len());
+                    for (mem, new_min) in root_info
+                        .defined_memories()
+                        .zip(snapshot.memory_mins.iter().copied())
+                    {
+                        let mut mem = translate::memory_type(mem);
+                        mem.limits.min = new_min;
+                        memories.memory(mem);
+                    }
+                    root.section(&memories);
+                }
+
+                // Encode the initialized global values from the snapshot,
+                // rather than the original values.
+                s if s.id == SectionId::Global.into() => {
+                    let mut globals = wasm_encoder::GlobalSection::new();
+                    for (glob_ty, val) in root_info.defined_globals().zip(snapshot.globals.iter()) {
+                        let glob_ty = translate::global_type(glob_ty);
+                        globals.global(
+                            glob_ty,
+                            match val {
+                                wasmtime::Val::I32(x) => wasm_encoder::Instruction::I32Const(*x),
+                                wasmtime::Val::I64(x) => wasm_encoder::Instruction::I64Const(*x),
+                                wasmtime::Val::F32(x) => {
+                                    wasm_encoder::Instruction::F32Const(f32::from_bits(*x))
+                                }
+                                wasmtime::Val::F64(x) => {
+                                    wasm_encoder::Instruction::F64Const(f64::from_bits(*x))
+                                }
+                                _ => unreachable!(),
+                            },
+                        );
+                    }
+                    root.section(&globals);
+                }
+
+                // Remove the initialization function's export and perform any
+                // requested renames.
+                s if s.id == SectionId::Export.into() => {
+                    let mut exports = wasm_encoder::ExportSection::new();
+                    for export in &root_info.exports {
+                        if export.field == self.init_func {
+                            continue;
+                        }
+
+                        if !renames.rename_src_to_dst.contains_key(export.field)
+                            && renames.rename_dsts.contains(export.field)
+                        {
+                            // A rename overwrites this export, and it is not
+                            // renamed to another export, so skip it.
+                            continue;
+                        }
+
+                        let field = renames
+                            .rename_src_to_dst
+                            .get(export.field)
+                            .map_or(export.field, |f| f.as_str());
+
+                        let mut export = translate::export(export.kind, export.index);
+                        if let wasm_encoder::Export::Instance(ref mut index) = export {
+                            *index = instance_renumbering.lookup(*index);
+                        }
+
+                        exports.export(field, export);
+                    }
+                    root.section(&exports);
+                }
+
+                // Skip the `start` function -- it's already been run!
+                s if s.id == SectionId::Start.into() => {
+                    continue;
+                }
+
+                s if s.id == SectionId::Element.into() => {
+                    root.section(s);
+                }
+
+                s if s.id == SectionId::Data.into() => {
+                    // TODO: supporting bulk memory will require copying over
+                    // any passive and declared segments.
+                    add_data_section(root);
+                }
+
+                s if s.id == SectionId::Code.into() => {
+                    root.section(s);
+                }
+
+                _ => unreachable!(),
+            }
+        }
+
+        // Make sure that we've added our data section to the module.
+        add_data_section(root);
+    }
+}
+
+fn is_name_section(s: &wasm_encoder::RawSection) -> bool {
+    s.id == SectionId::Custom.into() && {
+        let mut reader = wasmparser::BinaryReader::new(s.data);
+        matches!(reader.read_string(), Ok("name"))
+    }
+}
+
+/// Rewrite nested modules into a flat sequence, and where they import their
+/// state, rather than define it locally.
+///
+/// Returns the modules encoded in a module section and total number of code
+/// modules defined.
+fn rewrite_code_modules(
+    root_info: &ModuleInfo,
+    id_to_module_info: &Vec<&ModuleInfo>,
+) -> (wasm_encoder::ModuleSection, u32) {
+    let mut modules = wasm_encoder::ModuleSection::new();
+    let mut num_code_modules = 0;
+
+    root_info.pre_order(|info| {
+        // The root module is handled by `rewrite_root`; we are only dealing
+        // with nested children here.
+        if info.is_root() {
+            return;
+        }
+
+        let mut module = wasm_encoder::Module::new();
+
+        // We generally try to avoid renumbering entities in Wizer --
+        // particularly any entities referenced from the code section, where
+        // renumbering could change the size of a LEB128 index and break DWARF
+        // debug info offsets -- because it means we can't copy whole sections
+        // from the original, input Wasm module. But we run into a conflicting
+        // constraints here with regards to instances:
+        //
+        // 1. Ideally we would import our state instance last, so that we don't
+        //    perturb with our instance index space.
+        //
+        // 2. Locally-defined instances are state, and therefore must be pulled
+        //    out of these code modules into our imported state instance, and
+        //    then referenced via alias.
+        //
+        // (1) and (2) are in conflict because we can't create aliases of
+        // instances on the imported state instance until *after* the state
+        // instance is imported, which means we need to import our state
+        // instance first, which means we are forced to perturb the instance
+        // index space.
+        //
+        // Therefore, the first thing we add to each code module is an import
+        // section that imports the state instance. We need to explicitly
+        // rewrite all references to these instances (e.g. instance export
+        // aliases) to add one to their index so that they refer to the correct
+        // instance again. Luckily instances are never referenced from the code
+        // section, so DWARF debug info doesn't get invalidated.
+        //
+        // Finally, importing the state instance requires that we define the
+        // state instance's type. We really don't want to renumber types because
+        // those *are* referenced from the code section via `call_indirect`. To
+        // avoid renumbering types, we do a first pass over this module's types
+        // and build out a full type section with the same numbering as the
+        // original module, and then append the state import's type at the end.
+        let mut types = make_complete_type_section(info);
+        let import = make_state_import(info, &mut types, id_to_module_info);
+        module.section(&types);
+        module.section(&import);
+
+        // Now rewrite the initial sections one at a time.
+        //
+        // Note that the initial sections can occur repeatedly and in any
+        // order. This means that we only ever add, for example, `n` imports to
+        // the rewritten module when a particular import section defines `n`
+        // imports. We do *not* add all imports all at once. This is because
+        // imports and aliases might be interleaved, and adding all imports all
+        // at once could perturb entity numbering.
+        let mut sections = info.raw_sections.iter();
+        let mut imports = info.imports.iter();
+        let mut instantiations = 0..info.instantiations.len();
+        let mut aliases = info.aliases.iter();
+        let mut first_non_initial_section = None;
+        for section in sections.by_ref() {
+            match section {
+                // We handled this in `make_complete_type_section` above.
+                s if s.id == SectionId::Type.into() => continue,
+
+                // These are handled in subsequent steps of this pre-order
+                // traversal.
+                s if s.id == SectionId::Module.into() => continue,
+
+                s if s.id == SectionId::Import.into() => {
+                    let count = wasmparser::ImportSectionReader::new(s.data, 0)
+                        .unwrap()
+                        .get_count();
+                    let mut section = wasm_encoder::ImportSection::new();
+                    for imp in imports.by_ref().take(usize::try_from(count).unwrap()) {
+                        section.import(imp.module, imp.field, translate::entity_type(imp.ty));
+                    }
+                    module.section(&section);
+                }
+
+                // The actual instantiations are pulled out and handled in
+                // `rewrite_instantiations` and then we get them here via the
+                // state import. We need to bring them into scope via instance
+                // export aliases, however.
+                s if s.id == SectionId::Instance.into() => {
+                    let count = wasmparser::InstanceSectionReader::new(s.data, 0)
+                        .unwrap()
+                        .get_count();
+                    let mut section = wasm_encoder::AliasSection::new();
+                    for idx in instantiations
+                        .by_ref()
+                        .take(usize::try_from(count).unwrap())
+                    {
+                        // Our imported state instance is always instance 0.
+                        let from_instance = 0;
+                        let name = format!("__wizer_instance_{}", idx);
+                        section.instance_export(
+                            from_instance,
+                            wasm_encoder::ItemKind::Instance,
+                            &name,
+                        );
+                    }
+                    module.section(&section);
+                }
+
+                s if s.id == SectionId::Alias.into() => {
+                    let count = wasmparser::AliasSectionReader::new(s.data, 0)
+                        .unwrap()
+                        .get_count();
+                    let mut section = wasm_encoder::AliasSection::new();
+                    for alias in aliases.by_ref().take(usize::try_from(count).unwrap()) {
+                        match alias {
+                            // We don't make any instantiations so we don't need
+                            // modules here anymore.
+                            wasmparser::Alias::OuterModule { .. } => continue,
+                            // We already created a complete type section,
+                            // including any aliases, above.
+                            wasmparser::Alias::OuterType { .. } => continue,
+                            // Copy over instance export aliases.
+                            // however.
+                            wasmparser::Alias::InstanceExport {
+                                instance,
+                                kind,
+                                export,
+                            } => {
+                                // We need to add one to the instance's index
+                                // because our state instance import shifted
+                                // everything off by one.
+                                let from_instance = instance + 1;
+                                section.instance_export(
+                                    from_instance,
+                                    translate::item_kind(*kind),
+                                    export,
+                                );
+                            }
+                        }
+                    }
+                    module.section(&section);
+                }
+
+                s => {
+                    assert!(first_non_initial_section.is_none());
+                    first_non_initial_section = Some(s);
+                    break;
+                }
+            }
+        }
+
+        // We don't define the memories from the original memory section, but we
+        // do add instance export aliases for each of them from our imported
+        // state instance. These aliases need to be in an alias section, which
+        // is an initial section and must come before the rest of the
+        // non-initial sections. But it must also come *after* any memories that
+        // might have been imported, so that we don't mess up the
+        // numbering. Therefore we add these aliases here, after we've processed
+        // the initial sections, but before we start with the rest of the
+        // sections.
+        if let Some(defined_memories_index) = info.defined_memories_index {
+            let mut section = wasm_encoder::AliasSection::new();
+            let num_defined_memories =
+                info.memories.len() - usize::try_from(defined_memories_index).unwrap();
+            for mem in 0..num_defined_memories {
+                // Our state instance is always instance 0.
+                let from_instance = 0;
+                let name = format!("__wizer_memory_{}", mem);
+                section.instance_export(from_instance, wasm_encoder::ItemKind::Memory, &name);
+            }
+            module.section(&section);
+        }
+
+        // Globals are handled the same way as memories.
+        if let Some(defined_globals_index) = info.defined_globals_index {
+            let mut section = wasm_encoder::AliasSection::new();
+            let num_defined_globals =
+                info.globals.len() - usize::try_from(defined_globals_index).unwrap();
+            for mem in 0..num_defined_globals {
+                // Our state instance is always instance 0.
+                let from_instance = 0;
+                let name = format!("__wizer_global_{}", mem);
+                section.instance_export(from_instance, wasm_encoder::ItemKind::Global, &name);
+            }
+            module.section(&section);
+        }
+
+        // Process the rest of the non-initial sections.
+        for section in first_non_initial_section.into_iter().chain(sections) {
+            match section {
+                // We replaced these with instance export aliases from our state
+                // instance above.
+                s if s.id == SectionId::Memory.into() => continue,
+                s if s.id == SectionId::Global.into() => continue,
+
+                // We ignore the original data segments. We don't define
+                // memories anymore and state instances will define their own
+                // data segments based on the snapshot.
+                s if s.id == SectionId::Data.into() => continue,
+                s if s.id == SectionId::DataCount.into() => continue,
+
+                // The start function has already been run!
+                s if s.id == SectionId::Start.into() => continue,
+
+                // Finally, everything else is copied over as-is!
+                s => {
+                    module.section(s);
+                }
+            }
+        }
+
+        modules.module(&module);
+        num_code_modules += 1;
+    });
+
+    (modules, num_code_modules)
+}
+
+/// Flatten the `ModuleInfo` tree into a vector that maps each module id
+/// (i.e. pre-order index) to the associated module info.
+fn make_id_to_module_info<'a>(id_to_info: &mut Vec<&'a ModuleInfo<'a>>, info: &'a ModuleInfo<'a>) {
+    debug_assert_eq!(u32::try_from(id_to_info.len()).unwrap(), info.id);
+    id_to_info.push(info);
+    for m in &info.modules {
+        make_id_to_module_info(id_to_info, m);
+    }
+}
+
+/// Make a single complete type section for the given module info, regardless of
+/// how many initial type sections these types might have been defined within in
+/// the original module's serialization.
+fn make_complete_type_section(info: &ModuleInfo) -> wasm_encoder::TypeSection {
+    let mut types = wasm_encoder::TypeSection::new();
+    for ty in &info.types {
+        match ty {
+            wasmparser::TypeDef::Func(func_ty) => {
+                types.function(
+                    func_ty.params.iter().map(|ty| translate::val_type(*ty)),
+                    func_ty.returns.iter().map(|ty| translate::val_type(*ty)),
+                );
+            }
+            wasmparser::TypeDef::Instance(inst_ty) => {
+                types.instance(
+                    inst_ty
+                        .exports
+                        .iter()
+                        .map(|e| (e.name, translate::entity_type(e.ty))),
+                );
+            }
+            wasmparser::TypeDef::Module(_) => {
+                unreachable!(
+                    "we don't support importing/exporting modules so don't have to deal \
+                     with module types"
+                )
+            }
+        }
+    }
+    types
+}
+
+/// Make an import section that imports a code module's state instance import.
+fn make_state_import(
+    info: &ModuleInfo,
+    types: &mut wasm_encoder::TypeSection,
+    id_to_module_info: &Vec<&ModuleInfo>,
+) -> wasm_encoder::ImportSection {
+    let mut num_types = u32::try_from(info.types.len()).unwrap();
+
+    // Define instance types for each of the instances that we
+    // previously instantiated locally so that we can refer to
+    // these types in the state instance's type.
+    let instance_types = info
+        .instantiations
+        .values()
+        .map(|(m, _)| {
+            id_to_module_info[usize::try_from(*m).unwrap()]
+                .define_instance_type(&mut num_types, types)
+        })
+        .collect::<Vec<_>>();
+
+    // Define the state instance's type.
+    let state_instance_exports = info
+        .defined_globals()
+        .enumerate()
+        .map(|(i, g)| {
+            (
+                format!("__wizer_global_{}", i),
+                wasm_encoder::EntityType::Global(translate::global_type(g)),
+            )
+        })
+        .chain(info.defined_memories().enumerate().map(|(i, m)| {
+            (
+                format!("__wizer_memory_{}", i),
+                wasm_encoder::EntityType::Memory(translate::memory_type(m)),
+            )
+        }))
+        .chain(instance_types.iter().enumerate().map(|(i, type_index)| {
+            (
+                format!("__wizer_instance_{}", i),
+                wasm_encoder::EntityType::Instance(*type_index),
+            )
+        }))
+        .collect::<Vec<_>>();
+    let state_instance_type_index = num_types;
+    types.instance(
+        state_instance_exports
+            .iter()
+            .map(|(name, e)| (name.as_str(), *e)),
+    );
+
+    // Define the import of the state instance, using the type
+    // we just defined.
+    let mut imports = wasm_encoder::ImportSection::new();
+    imports.import(
+        "__wizer_state",
+        None,
+        wasm_encoder::EntityType::Instance(state_instance_type_index),
+    );
+    imports
+}
+
+/// Define the state modules for each instantiation.
+///
+/// These are modules that just define the memories/globals/nested instances of
+/// a particular instantiation and initialize them to the snapshot's state. They
+/// have no imports and export all of their internal state entities.
+///
+/// This does *not* instantiate the state modules in the resulting module
+/// section, just defines them (although nested state modules within these top
+/// level-state modules are instantiated inside these top-level state
+/// modules). That is because instantiation is handled differently depending on
+/// if the instantiation happens directly inside the root module (see the
+/// handling of instance sections in `rewrite_root`) or in a deeply nested
+/// module (in which case it is instantiated by its parent state module,
+/// i.e. another recursive invocation of this function that is one frame up the
+/// stack).
+fn rewrite_state_modules(
+    info: &ModuleInfo,
+    id_to_module_info: &Vec<&ModuleInfo>,
+    snapshots: &[Snapshot],
+    depth: u32,
+) -> wasm_encoder::ModuleSection {
+    let mut modules = wasm_encoder::ModuleSection::new();
+
+    assert_eq!(snapshots.len(), info.instantiations.len());
+    for (snapshot, (module_id, _)) in snapshots.iter().zip(info.instantiations.values()) {
+        let module_info = &id_to_module_info[usize::try_from(*module_id).unwrap()];
+        let state_module =
+            rewrite_one_state_module(module_info, id_to_module_info, snapshot, depth);
+        modules.module(&state_module);
+    }
+
+    modules
+}
+
+fn rewrite_one_state_module(
+    info: &ModuleInfo,
+    id_to_module_info: &Vec<&ModuleInfo>,
+    snapshot: &Snapshot,
+    depth: u32,
+) -> wasm_encoder::Module {
+    let mut state_module = wasm_encoder::Module::new();
+    let mut exports = wasm_encoder::ExportSection::new();
+
+    // If there are nested instantiations, then define the nested state
+    // modules and then instantiate them.
+    assert_eq!(info.instantiations.len(), snapshot.instantiations.len());
+    if !snapshot.instantiations.is_empty() {
+        // We create nested instantiations such that each state module has
+        // the following module index space:
+        //
+        // [
+        //     alias instantiation[0]'s code module,
+        //     alias instantiation[1]'s code module,
+        //     ...
+        //     alias instantiation[N]'s code module,
+        //     define instantiation[0]'s state module,
+        //     define instantiation[1]'s state module,
+        //     ...
+        //     define instantiation[N]'s state module,
+        // ]
+        //
+        // That is, the `i`th nested instantiation's code module is the `i`th
+        // module in the index space, and its state module is at index `N+i`.
+        //
+        // The instance index space is more complicated because of potential
+        // instance imports and aliasing imported instance's exported nested
+        // instances. These imported/aliased instances can then be used as
+        // arguments to a nested instantiation, and then the resulting instance
+        // can also be used as an argument to further nested instantiations. To
+        // handle all this, we use a `Renumbering` map for tracking instance
+        // indices.
+        let mut instance_renumbering = Renumbering::default();
+
+        let types = make_complete_type_section(&info);
+        state_module.section(&types);
+
+        let mut instance_import_counts = info.instance_import_counts.iter().copied();
+        let mut aliases = info.aliases.iter();
+        let mut instantiations = info.instantiations.values().enumerate();
+
+        for section in info.initial_sections() {
+            match section {
+                // Handled by `make_complete_type_section` above.
+                s if s.id == SectionId::Type.into() => continue,
+
+                // Copy the imports over and update our renumbering for any
+                // imported instances.
+                s if s.id == SectionId::Import.into() => {
+                    state_module.section(s);
+                    let instance_import_count = instance_import_counts.next().unwrap();
+                    for _ in 0..instance_import_count {
+                        instance_renumbering.add_import();
+                    }
+                }
+
+                // Update instance export aliases to use the numbered instance
+                // indices. Also update the renumbering for any aliased
+                // instances brought into scope.
+                s if s.id == SectionId::Alias.into() => {
+                    let count = wasmparser::AliasSectionReader::new(s.data, 0)
+                        .unwrap()
+                        .get_count();
+                    let mut section = wasm_encoder::AliasSection::new();
+                    for alias in aliases.by_ref().take(usize::try_from(count).unwrap()) {
+                        match alias {
+                            wasmparser::Alias::InstanceExport {
+                                instance,
+                                kind,
+                                export,
+                            } => {
+                                section.instance_export(
+                                    instance_renumbering.lookup(*instance),
+                                    translate::item_kind(*kind),
+                                    export,
+                                );
+                                // If this brought a new instance into our
+                                // instance index space, update our renumbering
+                                // map.
+                                if let wasmparser::ExternalKind::Instance = kind {
+                                    instance_renumbering.add_alias();
+                                }
+                            }
+                            // Handled by `make_complete_type_section`.
+                            wasmparser::Alias::OuterType { .. } => continue,
+                            // Ignore these because we alias only the modules we
+                            // need for nested instantiations below.
+                            wasmparser::Alias::OuterModule { .. } => continue,
+                        }
+                    }
+                    state_module.section(&section);
+                }
+
+                // We alias only the modules we need for nested instantiations
+                // below.
+                s if s.id == SectionId::Module.into() => continue,
+
+                // For each nested instantiation in this section, alias its code
+                // module, define its state module, instantiate the state module
+                // to create the state instance, instantiate the code module
+                // with the state instance, and finally export the code+state
+                // instance.
+                s if s.id == SectionId::Instance.into() => {
+                    let count = wasmparser::InstanceSectionReader::new(s.data, 0)
+                        .unwrap()
+                        .get_count();
+                    let mut alias_section = wasm_encoder::AliasSection::new();
+                    let mut instance_section = wasm_encoder::InstanceSection::new();
+                    let mut module_section = wasm_encoder::ModuleSection::new();
+                    for (i, (module_id, instance_args)) in instantiations
+                        .by_ref()
+                        .take(usize::try_from(count).unwrap())
+                    {
+                        // Alias this instantiation's code module.
+                        //
+                        // Because we flatten the code modules into the root
+                        // with a pre-order traversal, the module id is the
+                        // module's pre-order index, and the root module is not
+                        // in the flattened list, this instantiation's code
+                        // module is the `module_id - 1`th module in the root
+                        // module's module index space.
+                        let root_module_index = *module_id - 1;
+                        alias_section.outer_module(depth, root_module_index);
+
+                        // Define the state module for this instantiation.
+                        let state_module = rewrite_one_state_module(
+                            id_to_module_info[usize::try_from(*module_id).unwrap()],
+                            id_to_module_info,
+                            &snapshot.instantiations[i],
+                            depth + 1,
+                        );
+                        module_section.module(&state_module);
+
+                        // Instantiate the state module to create the state
+                        // instance.
+                        let args: Vec<_> = instance_args
+                            .iter()
+                            .map(|arg| {
+                                let mut arg = translate::instance_arg(arg);
+                                if let (_name, wasm_encoder::Export::Instance(ref mut index)) = arg
+                                {
+                                    *index = instance_renumbering.lookup(*index);
+                                }
+                                arg
+                            })
+                            .collect();
+                        instance_section.instantiate(
+                            u32::try_from(snapshot.instantiations.len() + i).unwrap(),
+                            args,
+                        );
+                        let state_instance_index = instance_renumbering.define_new();
+
+                        // Then instantiate the associated code module, passing it this
+                        // state instance and whatever other arguments it expects.
+                        let args: Vec<_> = iter::once((
+                            "__wizer_state",
+                            wasm_encoder::Export::Instance(state_instance_index),
+                        ))
+                        .chain(instance_args.iter().map(|arg| {
+                            let mut arg = translate::instance_arg(arg);
+                            if let (_name, wasm_encoder::Export::Instance(ref mut index)) = arg {
+                                *index = instance_renumbering.lookup(*index);
+                            }
+                            arg
+                        }))
+                        .collect();
+                        instance_section.instantiate(u32::try_from(i).unwrap(), args);
+                        let (_, code_and_state_instance_index) = instance_renumbering.define_both();
+
+                        // Add the export for this nested instance.
+                        let name = format!("__wizer_instance_{}", i);
+                        exports.export(
+                            &name,
+                            wasm_encoder::Export::Instance(
+                                u32::try_from(code_and_state_instance_index).unwrap(),
+                            ),
+                        );
+                    }
+                    state_module.section(&alias_section);
+                    state_module.section(&module_section);
+                    state_module.section(&instance_section);
+                }
+
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    // Add defined memories.
+    assert_eq!(info.defined_memories_len(), snapshot.memory_mins.len());
+    if info.defined_memories_index.is_some() {
+        let mut memories = wasm_encoder::MemorySection::new();
+        for (i, (new_min, mem)) in snapshot
+            .memory_mins
+            .iter()
+            .copied()
+            .zip(info.defined_memories())
+            .enumerate()
+        {
+            let mut mem = translate::memory_type(mem);
+            assert!(new_min >= mem.limits.min);
+            assert!(new_min <= mem.limits.max.unwrap_or(u32::MAX));
+            mem.limits.min = new_min;
+            memories.memory(mem);
+
+            let name = format!("__wizer_memory_{}", i);
+            exports.export(
+                &name,
+                wasm_encoder::Export::Memory(u32::try_from(i).unwrap()),
+            );
+        }
+        state_module.section(&memories);
+    }
+
+    // Add defined globals.
+    assert_eq!(info.defined_globals_len(), snapshot.globals.len());
+    if info.defined_globals_index.is_some() {
+        let mut globals = wasm_encoder::GlobalSection::new();
+        for (i, (val, glob_ty)) in snapshot
+            .globals
+            .iter()
+            .zip(info.defined_globals())
+            .enumerate()
+        {
+            let glob_ty = translate::global_type(glob_ty);
+            globals.global(
+                glob_ty,
+                match val {
+                    wasmtime::Val::I32(x) => wasm_encoder::Instruction::I32Const(*x),
+                    wasmtime::Val::I64(x) => wasm_encoder::Instruction::I64Const(*x),
+                    wasmtime::Val::F32(x) => {
+                        wasm_encoder::Instruction::F32Const(f32::from_bits(*x))
+                    }
+                    wasmtime::Val::F64(x) => {
+                        wasm_encoder::Instruction::F64Const(f64::from_bits(*x))
+                    }
+                    _ => unreachable!(),
+                },
+            );
+
+            let name = format!("__wizer_global_{}", i);
+            exports.export(
+                &name,
+                wasm_encoder::Export::Global(u32::try_from(i).unwrap()),
+            );
+        }
+        state_module.section(&globals);
+    }
+
+    state_module.section(&exports);
+
+    // Add data segments.
+    if !snapshot.data_segments.is_empty() {
+        let mut data = wasm_encoder::DataSection::new();
+        for seg in &snapshot.data_segments {
+            data.active(
+                seg.memory_index,
+                wasm_encoder::Instruction::I32Const(seg.offset as i32),
+                seg.data.iter().copied(),
+            );
+        }
+        state_module.section(&data);
+    }
+
+    state_module
+}

--- a/src/rewrite/renumbering.rs
+++ b/src/rewrite/renumbering.rs
@@ -1,0 +1,57 @@
+use std::convert::TryFrom;
+
+/// A renumbering of indices.
+///
+/// Keeps track of which indices in the original Wasm map to which indices in
+/// the rewritten Wasm.
+///
+/// Only supports injective renumberings: every old index has a corresponding
+/// unique new index, but each new index does not need to have a corresponding
+/// old index.
+#[derive(Default, Debug)]
+pub struct Renumbering {
+    old_count: u32,
+    new_count: u32,
+    old_to_new: Vec<u32>,
+}
+
+impl Renumbering {
+    /// Define an entry in both the old and new index spaces. Returns a tuple of
+    /// the old and new indices.
+    pub fn define_both(&mut self) -> (u32, u32) {
+        debug_assert_eq!(
+            self.old_to_new.len(),
+            usize::try_from(self.old_count).unwrap()
+        );
+        self.old_to_new.push(self.new_count);
+        self.old_count += 1;
+        self.new_count += 1;
+        (self.old_count - 1, self.new_count - 1)
+    }
+
+    /// Add an import to both the old and new index spaces. Returns a tuple of
+    /// the old and new indices.
+    pub fn add_import(&mut self) -> (u32, u32) {
+        self.define_both()
+    }
+
+    /// Add an alias to both the old and new index spaces. Returns a tuple of
+    /// the old and new indices.
+    pub fn add_alias(&mut self) -> (u32, u32) {
+        self.define_both()
+    }
+
+    /// Add an entry to the new index space. Returns the entry's index in the
+    /// new index space.
+    pub fn define_new(&mut self) -> u32 {
+        self.new_count += 1;
+        self.new_count - 1
+    }
+
+    /// Get the new index for the given old index.
+    ///
+    /// Panics when `old` is not in the old index space.
+    pub fn lookup(&self, old: u32) -> u32 {
+        self.old_to_new[usize::try_from(old).unwrap()]
+    }
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -168,14 +168,12 @@ fn snapshot_instantiations<'a>(
 ) -> Vec<Snapshot<'a>> {
     log::debug!("Snapshotting nested instantiations");
     let mut instantiations = vec![];
-    let mut index = 0;
     loop {
-        let name = format!("__wizer_instance_{}", index);
+        let name = format!("__wizer_instance_{}", instantiations.len());
         match instance.get_export(&name) {
             None => break,
             Some(wasmtime::Extern::Instance(instance)) => {
                 instantiations.push(snapshot(store, &instance));
-                index += 1;
             }
             Some(_) => unreachable!(),
         }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,185 @@
+use rayon::iter::{IntoParallelIterator, ParallelExtend, ParallelIterator};
+use std::convert::TryFrom;
+
+const WASM_PAGE_SIZE: u32 = 65_536;
+const NATIVE_PAGE_SIZE: u32 = 4_096;
+
+/// A "snapshot" of Wasm state from its default value after having been initialized.
+pub struct Snapshot<'a> {
+    /// Maps global index to its initialized value.
+    pub globals: Vec<wasmtime::Val>,
+
+    /// A new minimum size for each memory (in units of pages).
+    pub memory_mins: Vec<u32>,
+
+    /// Segments of non-zero memory.
+    pub data_segments: Vec<DataSegment<'a>>,
+
+    /// Snapshots for each nested instantiation.
+    pub instantiations: Vec<Snapshot<'a>>,
+}
+
+/// A data segment initializer for a memory.
+pub struct DataSegment<'a> {
+    /// The index of this data segment's memory.
+    pub memory_index: u32,
+    /// The offset within the memory that `data` should be copied to.
+    pub offset: u32,
+    /// This segment's (non-zero) data.
+    pub data: &'a [u8],
+}
+
+/// Snapshot the given instance's globals, memories, and instances from the Wasm
+/// defaults.
+//
+// TODO: when we support reference types, we will have to snapshot tables.
+pub fn snapshot<'a>(store: &'a wasmtime::Store, instance: &wasmtime::Instance) -> Snapshot<'a> {
+    log::debug!("Snapshotting the initialized state");
+
+    assert!(wasmtime::Store::same(store, &instance.store()));
+
+    let globals = snapshot_globals(instance);
+    let (memory_mins, data_segments) = snapshot_memories(instance);
+    let instantiations = snapshot_instantiations(store, instance);
+
+    Snapshot {
+        globals,
+        memory_mins,
+        data_segments,
+        instantiations,
+    }
+}
+
+/// Get the initialized values of all globals.
+fn snapshot_globals(instance: &wasmtime::Instance) -> Vec<wasmtime::Val> {
+    log::debug!("Snapshotting global values");
+    let mut globals = vec![];
+    let mut index = 0;
+    loop {
+        let name = format!("__wizer_global_{}", index);
+        match instance.get_global(&name) {
+            None => break,
+            Some(global) => {
+                globals.push(global.get());
+                index += 1;
+            }
+        }
+    }
+    globals
+}
+
+/// Find the initialized minimum page size of each memory, as well as all
+/// regions of non-zero memory.
+fn snapshot_memories<'a>(instance: &wasmtime::Instance) -> (Vec<u32>, Vec<DataSegment<'a>>) {
+    log::debug!("Snapshotting memories");
+
+    // Find and record non-zero regions of memory (in parallel).
+    let mut memory_mins = vec![];
+    let mut data_segments = vec![];
+    let mut memory_index = 0;
+    loop {
+        let name = format!("__wizer_memory_{}", memory_index);
+        match instance.get_memory(&name) {
+            None => break,
+            Some(memory) => {
+                memory_mins.push(memory.size());
+
+                let num_wasm_pages = memory.size();
+                let num_native_pages = num_wasm_pages * (WASM_PAGE_SIZE / NATIVE_PAGE_SIZE);
+
+                let memory: &'a [u8] = unsafe {
+                    // Safe because no one else has a (potentially mutable)
+                    // view to this memory and we know the memory will live
+                    // as long as the store is alive.
+                    std::slice::from_raw_parts(memory.data_ptr(), memory.data_size())
+                };
+
+                // Consider each "native" page of the memory. (Scare quotes
+                // because we have no guarantee that anyone isn't using huge
+                // page sizes or something). Process each page in
+                // parallel. If any byte has changed, add the whole page as
+                // a data segment. This means that the resulting Wasm module
+                // should instantiate faster, since there are fewer segments
+                // to bounds check on instantiation. Engines could even
+                // theoretically recognize that each of these segments is
+                // page sized and aligned, and use lazy copy-on-write
+                // initialization of each instance's memory.
+                data_segments.par_extend((0..num_native_pages).into_par_iter().filter_map(|i| {
+                    let start = i * NATIVE_PAGE_SIZE;
+                    let end = ((i + 1) * NATIVE_PAGE_SIZE) as usize;
+                    let page = &memory[start as usize..end];
+                    for byte in page {
+                        if *byte != 0 {
+                            return Some(DataSegment {
+                                memory_index,
+                                offset: start as u32,
+                                data: page,
+                            });
+                        }
+                    }
+                    None
+                }));
+
+                memory_index += 1;
+            }
+        }
+    }
+
+    // Sort data segments to enforce determinism in the face of the
+    // parallelism above.
+    data_segments.sort_by_key(|s| (s.memory_index, s.offset));
+
+    // Merge any contiguous pages, so that the engine can initialize them
+    // all at once (ideally with a single copy-on-write `mmap`) rather than
+    // initializing each data segment individually.
+    for i in (1..data_segments.len()).rev() {
+        let a = &data_segments[i - 1];
+        let b = &data_segments[i];
+
+        // Only merge segments for the same memory.
+        if a.memory_index != b.memory_index {
+            continue;
+        }
+
+        // Only merge segments if they are contiguous.
+        if a.offset + u32::try_from(a.data.len()).unwrap() != b.offset {
+            continue;
+        }
+
+        // Okay, merge them together into `a` (so that the next iteration
+        // can merge it with its predecessor) and then remove `b`!
+        data_segments[i - 1].data = unsafe {
+            debug_assert_eq!(
+                a.data
+                    .as_ptr()
+                    .offset(isize::try_from(a.data.len()).unwrap()),
+                b.data.as_ptr()
+            );
+            std::slice::from_raw_parts(a.data.as_ptr(), a.data.len() + b.data.len())
+        };
+        data_segments.remove(i);
+    }
+
+    (memory_mins, data_segments)
+}
+
+fn snapshot_instantiations<'a>(
+    store: &'a wasmtime::Store,
+    instance: &wasmtime::Instance,
+) -> Vec<Snapshot<'a>> {
+    log::debug!("Snapshotting nested instantiations");
+    let mut instantiations = vec![];
+    let mut index = 0;
+    loop {
+        let name = format!("__wizer_instance_{}", index);
+        match instance.get_export(&name) {
+            None => break,
+            Some(wasmtime::Extern::Instance(instance)) => {
+                instantiations.push(snapshot(store, &instance));
+                index += 1;
+            }
+            Some(_) => unreachable!(),
+        }
+    }
+    instantiations
+}

--- a/src/stack_ext.rs
+++ b/src/stack_ext.rs
@@ -1,0 +1,16 @@
+/// An extension trait for getting the top element on a stack with an implicit
+/// unwrap for if the stack is empty.
+pub(crate) trait StackExt<T> {
+    fn top(&self) -> &T;
+    fn top_mut(&mut self) -> &mut T;
+}
+
+impl<T> StackExt<T> for Vec<T> {
+    fn top(&self) -> &T {
+        self.last().unwrap()
+    }
+
+    fn top_mut(&mut self) -> &mut T {
+        self.last_mut().unwrap()
+    }
+}

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1,0 +1,104 @@
+//! Type translator functions from `wasmparser` to `wasm_encoder`.
+
+pub(crate) fn table_type(table_ty: wasmparser::TableType) -> wasm_encoder::TableType {
+    wasm_encoder::TableType {
+        element_type: val_type(table_ty.element_type),
+        limits: limits(table_ty.limits),
+    }
+}
+
+pub(crate) fn val_type(ty: wasmparser::Type) -> wasm_encoder::ValType {
+    use wasm_encoder::ValType;
+    use wasmparser::Type::*;
+    match ty {
+        I32 => ValType::I32,
+        I64 => ValType::I64,
+        F32 => ValType::F32,
+        F64 => ValType::F64,
+        FuncRef => ValType::FuncRef,
+        V128 | ExternRef | ExnRef => panic!("not supported"),
+        Func | EmptyBlockType => unreachable!(),
+    }
+}
+
+pub(crate) fn global_type(ty: wasmparser::GlobalType) -> wasm_encoder::GlobalType {
+    wasm_encoder::GlobalType {
+        val_type: val_type(ty.content_type),
+        mutable: ty.mutable,
+    }
+}
+
+pub(crate) fn memory_type(ty: wasmparser::MemoryType) -> wasm_encoder::MemoryType {
+    match ty {
+        wasmparser::MemoryType::M32 {
+            shared: false,
+            limits: lims,
+        } => wasm_encoder::MemoryType {
+            limits: limits(lims),
+        },
+        _ => unreachable!("handled in validation"),
+    }
+}
+
+pub(crate) fn limits(limits: wasmparser::ResizableLimits) -> wasm_encoder::Limits {
+    wasm_encoder::Limits {
+        min: limits.initial,
+        max: limits.maximum,
+    }
+}
+
+pub(crate) fn entity_type(ty: wasmparser::ImportSectionEntryType) -> wasm_encoder::EntityType {
+    match ty {
+        wasmparser::ImportSectionEntryType::Function(f) => wasm_encoder::EntityType::Function(f),
+        wasmparser::ImportSectionEntryType::Table(tty) => {
+            wasm_encoder::EntityType::Table(table_type(tty))
+        }
+        wasmparser::ImportSectionEntryType::Memory(mty) => {
+            wasm_encoder::EntityType::Memory(memory_type(mty))
+        }
+        wasmparser::ImportSectionEntryType::Global(gty) => {
+            wasm_encoder::EntityType::Global(global_type(gty))
+        }
+        wasmparser::ImportSectionEntryType::Instance(ity) => {
+            wasm_encoder::EntityType::Instance(ity)
+        }
+        wasmparser::ImportSectionEntryType::Module(_) => {
+            unreachable!(
+                "we disallow importing/exporting modules so we shouldn't \
+                 have module types"
+            )
+        }
+        wasmparser::ImportSectionEntryType::Event(_) => unreachable!(),
+    }
+}
+
+pub(crate) fn item_kind(kind: wasmparser::ExternalKind) -> wasm_encoder::ItemKind {
+    match kind {
+        wasmparser::ExternalKind::Function => wasm_encoder::ItemKind::Function,
+        wasmparser::ExternalKind::Table => wasm_encoder::ItemKind::Table,
+        wasmparser::ExternalKind::Memory => wasm_encoder::ItemKind::Memory,
+        wasmparser::ExternalKind::Global => wasm_encoder::ItemKind::Global,
+        wasmparser::ExternalKind::Module => wasm_encoder::ItemKind::Module,
+        wasmparser::ExternalKind::Instance => wasm_encoder::ItemKind::Instance,
+        wasmparser::ExternalKind::Type | wasmparser::ExternalKind::Event => unreachable!(),
+    }
+}
+
+pub(crate) fn export(kind: wasmparser::ExternalKind, index: u32) -> wasm_encoder::Export {
+    match kind {
+        wasmparser::ExternalKind::Function => wasm_encoder::Export::Function(index),
+        wasmparser::ExternalKind::Global => wasm_encoder::Export::Global(index),
+        wasmparser::ExternalKind::Table => wasm_encoder::Export::Table(index),
+        wasmparser::ExternalKind::Memory => wasm_encoder::Export::Memory(index),
+        wasmparser::ExternalKind::Instance => wasm_encoder::Export::Instance(index),
+        wasmparser::ExternalKind::Event
+        | wasmparser::ExternalKind::Type
+        | wasmparser::ExternalKind::Module => unreachable!(),
+    }
+}
+
+pub(crate) fn instance_arg<'a>(
+    arg: &wasmparser::InstanceArg<'a>,
+) -> (&'a str, wasm_encoder::Export) {
+    (arg.name, export(arg.kind, arg.index))
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -505,6 +505,41 @@ fn start_sections_in_nested_modules() -> anyhow::Result<()> {
 }
 
 #[test]
+fn outer_module_alias() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (module $A
+    (global (export "g") (mut i32) (i32.const 0))
+  )
+
+  (module $B
+    (alias outer 0 0 (module $A))
+    (instance $a (instantiate $A))
+    (func (export "init")
+      i32.const 42
+      global.set (global $a "g")
+    )
+    (func (export "run") (result i32)
+      global.get (global $a "g")
+    )
+  )
+  (instance $b (instantiate $B))
+
+  (func (export "wizer.initialize")
+    call (func $b "init")
+  )
+  (func (export "run") (result i32)
+    call (func $b "run")
+  )
+)
+"#,
+    )
+}
+
+#[test]
 fn rust_regex() -> anyhow::Result<()> {
     run_wasm(
         &[wasmtime::Val::I32(13)],

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use wat::parse_str as wat_to_wasm;
 use wizer::Wizer;
 
@@ -12,15 +13,19 @@ fn run_wasm(args: &[wasmtime::Val], expected: i32, wasm: &[u8]) -> anyhow::Resul
 
     let mut wizer = Wizer::new();
     wizer.allow_wasi(true);
+    wizer.wasm_multi_memory(true);
+    wizer.wasm_module_linking(true);
     let wasm = wizer.run(&wasm)?;
 
     let mut config = wasmtime::Config::new();
     config.wasm_multi_memory(true);
     config.wasm_multi_value(true);
+    config.wasm_module_linking(true);
 
     let engine = wasmtime::Engine::new(&config)?;
     let store = wasmtime::Store::new(&engine);
-    let module = wasmtime::Module::new(store.engine(), wasm)?;
+    let module =
+        wasmtime::Module::new(store.engine(), wasm).context("Wasm test case failed to compile")?;
 
     let mut linker = wasmtime::Linker::new(&store);
     let ctx = wasi_cap_std_sync::WasiCtxBuilder::new().build()?;
@@ -111,6 +116,394 @@ fn multi_memory() -> anyhow::Result<()> {
 }
 
 #[test]
+fn reject_imported_memory() -> anyhow::Result<()> {
+    assert!(run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (import "" "" (memory 1)))
+"#,
+    )
+    .is_err());
+    Ok(())
+}
+
+#[test]
+fn reject_imported_global() -> anyhow::Result<()> {
+    assert!(run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (import "" "" (global i32)))
+"#,
+    )
+    .is_err());
+    Ok(())
+}
+
+#[test]
+fn reject_imported_table() -> anyhow::Result<()> {
+    assert!(run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (import "" "" (table)))
+"#,
+    )
+    .is_err());
+    Ok(())
+}
+
+#[test]
+fn reject_bulk_memory() -> anyhow::Result<()> {
+    let result = run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (table 3 funcref)
+
+  (func $f (result i32) (i32.const 0))
+  (func $g (result i32) (i32.const 0))
+  (func $h (result i32) (i32.const 0))
+
+  (func (export "main")
+    i32.const 0
+    i32.const 1
+    i32.const 1
+    table.copy)
+
+  (elem (i32.const 0) $f $g $h)
+)
+"#,
+    );
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("unsupported `table.copy` instruction"));
+
+    Ok(())
+}
+
+#[test]
+fn accept_module_linking_import_memory() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (module $A
+    (memory (export "memory") 1))
+  (instance $a (instantiate $A))
+
+  (module $B
+    (import "x" (instance $x (export "memory" (memory 1)))))
+  (instance $b (instantiate $B (import "x" (instance $a))))
+
+  (func (export "wizer.initialize")
+    nop)
+
+  (func (export "run") (result i32)
+    i32.const 42)
+)
+"#,
+    )
+}
+
+#[test]
+fn accept_module_linking_import_global() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (module $A
+    (global (export "global") i32 (i32.const 1337)))
+  (instance $a (instantiate $A))
+
+  (module $B
+    (import "x" (instance $x (export "global" (global i32)))))
+  (instance $b (instantiate $B (import "x" (instance $a))))
+
+  (func (export "wizer.initialize")
+    nop)
+
+  (func (export "run") (result i32)
+    i32.const 42)
+)
+"#,
+    )
+}
+
+#[test]
+fn accept_module_linking_import_table() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (module $A
+    (table (export "table") 0 funcref))
+  (instance $a (instantiate $A))
+
+  (module $B
+    (import "x" (instance $x (export "table" (table 0 funcref)))))
+  (instance $b (instantiate $B (import "x" (instance $a))))
+
+  (func (export "wizer.initialize")
+    nop)
+
+  (func (export "run") (result i32)
+    i32.const 42)
+)
+"#,
+    )
+}
+
+#[test]
+fn module_linking_actually_works() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (module $memory-module
+    (memory (export "memory") 1))
+  (instance $memory-instance (instantiate $memory-module))
+
+  (module $use-memory
+    (import "x" (instance $m (export "memory" (memory 1))))
+    (func (export "init")
+      i32.const 0
+      i32.const 42
+      i32.store (memory $m "memory") offset=1337))
+  (instance $use-memory-instance
+    (instantiate $use-memory
+      (import "x" (instance $memory-instance))))
+
+  (func (export "wizer.initialize")
+    (call (func $use-memory-instance "init")))
+
+  (func (export "run") (result i32)
+    i32.const 0
+    i32.load (memory $memory-instance "memory") offset=1337)
+)
+"#,
+    )
+}
+
+#[test]
+fn module_linking_nested_instantiations_1() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        8,
+        r#"
+(module
+  (module $A
+    (import "global" (global (mut i32)))
+
+    (module $B
+      (import "global" (global (mut i32)))
+
+        (module $C
+          (import "global" (global (mut i32)))
+
+          (func (export "f")
+            i32.const 1
+            global.get 0
+            i32.add
+            global.set 0
+          )
+        )
+
+        (instance $c1 (instantiate $C (import "global" (global 0))))
+        (instance $c2 (instantiate $C (import "global" (global 0))))
+
+        (func (export "f")
+          call (func $c1 "f")
+          call (func $c2 "f")
+       )
+    )
+
+    (instance $b1 (instantiate $B (import "global" (global 0))))
+    (instance $b2 (instantiate $B (import "global" (global 0))))
+
+    (func (export "f")
+      call (func $b1 "f")
+      call (func $b2 "f")
+    )
+  )
+
+  (module $DefinesGlobal
+    (global (export "global") (mut i32) (i32.const 0)))
+  (instance $global_instance (instantiate $DefinesGlobal))
+
+  (instance $a1 (instantiate $A (import "global" (global $global_instance "global"))))
+  (instance $a2 (instantiate $A (import "global" (global $global_instance "global"))))
+
+  (func (export "wizer.initialize")
+    call (func $a1 "f")
+    call (func $a2 "f"))
+
+  (func (export "run") (result i32)
+    global.get (global $global_instance "global"))
+)
+"#,
+    )
+}
+
+#[test]
+fn module_linking_nested_instantiations_0() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (module $A
+    (import "global" (global (mut i32)))
+
+    (module $B
+      (import "global" (global (mut i32)))
+
+       (func (export "f")
+         i32.const 42
+         global.set 0
+       )
+    )
+
+    (instance $b (instantiate $B (import "global" (global 0))))
+
+    (func (export "f")
+      call (func $b "f")
+    )
+  )
+
+  (module $G
+    (global (export "global") (mut i32) (i32.const 0)))
+
+  (instance $g (instantiate $G))
+
+  (instance $a (instantiate $A (import "global" (global $g "global"))))
+
+  (func (export "wizer.initialize")
+    call (func $a "f")
+  )
+
+  (func (export "run") (result i32)
+    global.get (global $g "global")
+  )
+)
+"#,
+    )
+}
+
+// Test that we handle repeated and interleaved initial sections.
+#[test]
+fn multiple_initial_sections() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  ;; Module section.
+  (module $A
+    (memory (export "memory") 1)
+  )
+
+  ;; Instance section.
+  (instance $a (instantiate $A))
+
+  ;; Alias section.
+  (alias $a "memory" (memory $memory))
+
+  ;; Module section.
+  (module $B
+    (import "memory" (memory 1))
+    (func (export "init")
+      i32.const 0
+      i32.const 42
+      i32.store offset=1337
+    )
+  )
+
+  ;; Instance section.
+  (instance $b (instantiate $B (import "memory" (memory $memory))))
+
+  ;; Alias section.
+  (alias $b "init" (func $b-init))
+
+  ;; Module section.
+  (module $C
+    (import "memory" (memory 1))
+    (func (export "run") (result i32)
+      i32.const 0
+      i32.load offset=1337
+    )
+  )
+
+  ;; Instance section.
+  (instance $c (instantiate $C (import "memory" (memory $memory))))
+
+  ;; Alias section.
+  (alias $c "run" (func $c-run))
+
+  ;; Done with initial sections.
+
+  (func (export "wizer.initialize")
+    call $b-init
+  )
+
+  (func (export "run") (result i32)
+    call $c-run
+  )
+)
+"#,
+    )
+}
+
+#[test]
+fn start_sections_in_nested_modules() -> anyhow::Result<()> {
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (module $A
+    (import "global" (global $g (mut i32)))
+    (func $init
+      i32.const 41
+      global.set $g)
+    (start $init)
+  )
+
+  (module $B
+    (global (export "global") (mut i32) (i32.const 0))
+  )
+
+  (instance $b (instantiate $B))
+  (alias $b "global" (global $g))
+  (instance $a (instantiate $A (import "global" (global $g))))
+
+  (func (export "wizer.initialize")
+    global.get $g
+    i32.const 1
+    i32.add
+    global.set $g
+  )
+  (func (export "run") (result i32)
+    global.get $g
+  )
+)
+"#,
+    )
+}
+
+#[test]
 fn rust_regex() -> anyhow::Result<()> {
     run_wasm(
         &[wasmtime::Val::I32(13)],
@@ -125,11 +518,11 @@ fn rename_functions() -> anyhow::Result<()> {
 (module
  (func (export "wizer.initialize"))
  (func (export "func_a") (result i32)
-  i32.const 1)
+   i32.const 1)
  (func (export "func_b") (result i32)
-  i32.const 2)
+   i32.const 2)
  (func (export "func_c") (result i32)
-  i32.const 3))
+   i32.const 3))
   "#;
 
     let wasm = wat_to_wasm(wat)?;
@@ -138,6 +531,7 @@ fn rename_functions() -> anyhow::Result<()> {
     wizer.func_rename("func_a", "func_b");
     wizer.func_rename("func_b", "func_c");
     let wasm = wizer.run(&wasm)?;
+    let wat = wasmprinter::print_bytes(&wasm)?;
 
     let expected_wat = r#"
 (module
@@ -154,9 +548,6 @@ fn rename_functions() -> anyhow::Result<()> {
   (export "func_b" (func 3)))
   "#;
 
-    let expected_wasm = wat_to_wasm(expected_wat)?;
-
-    assert_eq!(expected_wasm, wasm);
-
+    assert_eq!(wat.trim(), expected_wat.trim());
     Ok(())
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ fn run_wasm(args: &[wasmtime::Val], expected: i32, wasm: &[u8]) -> anyhow::Resul
     let wasm = wizer.run(&wasm)?;
 
     let mut config = wasmtime::Config::new();
+    config.cache_config_load_default().unwrap();
     config.wasm_multi_memory(true);
     config.wasm_multi_value(true);
     config.wasm_module_linking(true);


### PR DESCRIPTION
This pull request adds support for 99% of module linking to Wizer. This allows modules
within the "bundle" to import/export memories, globals, tables, and instances
from/to each other, but the root module still cannot import any external
state. The one big feature from module linking that isn't supported yet is
importing and exporting modules, rather than instances. More on this restriction
later.

Module linking breaks Wizer's previous assumption that a module is instantiated
and initialized exactly once (or, at least, that if it were instantiated and
initialized multiple times you would get the same result every time due to the
restrictions on imports and what can be used during initialization). Module
linking allows the same module to be instantiated multiple times and have a
different set of functions called on each instance during initialization. This
can lead to distinct initialized states for each instantiation. Here is a simple
example:

```wat
(module
  (module $A
    (global $g (mut i32) (i32.const 0))
    (func (export "f")
      global.get $g
      i32.const 1
      i32.add
      global.set $g))
  (instance $a1 (instantiate $A))
  (instance $a2 (instantiate $A))
  (func (export "wizer.initialize")
    call (func $a1 "f")
    call (func $a2 "f")
    call (func $a2 "f")))
```

After initialization, the `$a1` instance has had its `f` function export called
once and therefore its global's value is 1, while `$a2` has had its `f` function
export called twice and therefore its global's value is 2. Because each
instantiation has its own initialized state, we need to emit a pre-initialized
module for _each_ instantiation in the bundle.

At the same time, however, we do _not_ want to duplicate the `f` function across
each pre-initialized module! The code section is generally the largest section
in a Wasm module, and if we naively duplicated the code section for each
instantiation, we could get exponential code size blow ups. (For example,
consider a module linking bundle that contains a leaf module named `$Module1`
that is instantiated twice in another module called `$Module2`, which is in turn
instantiated twice in `$Module4`, which is in turn instantiated twice in
`$Module8`, etc... If the last module in this chain is instantiated `n` times,
then `$Module1` is instantiated `2^n` times, and if we duplicate the code
section for each instantiation we've got `2^n` copies of `$Module1`'s code
section.)

The solution is to split out a "code module" containing only the static sections
from the original module. All the state in the module (memories, globals, and
nested instantiations) are imported via a `__wizer_state` instance import. Then,
each instantiation defines its own "state module" which contains the specific
initialized state for that instance, and which is instantiated exactly once. To
create the initialized version of the original instantiation, we join the state
with the code by instantiating the code module and passing in this
instantiation's state instance.

Let's return to our original example from above. Here is the input Wasm again:

```wat
(module
  (module $A
    (global $g (mut i32) (i32.const 0))
    (func (export "f")
      global.get $g
      i32.const 1
      i32.add
      global.set $g))
  (instance $a1 (instantiate $A))
  (instance $a2 (instantiate $A))
  (func (export "wizer.initialize")
    call (func $a1 "f")
    call (func $a2 "f")
    call (func $a2 "f")))
```

And this is roughly what it looks like after wizening:

```wat
(module
  ;; The code module for $A.
  (module $A_code
    ;; Note that the code module imports state, rather than defining it.
    (import "__wizer_state"
      (instance (export "__wizer_global_0" (global $g (mut i32)))))
    (func (export "f")
      global.get $g
      i32.const 1
      i32.add
      global.set $g))

  ;; State module for $a1. Global is initialized to 1 since $a1's `f`
  ;; function was called once in the initialization.
  (module $a1_state_module
    (global (export "__wizer_global_0" (mut i32) (i32.const 1))))

  ;; The state instance for $a1.
  (instance $a1_state_instance (instantiate $a1_state_module))

  ;; Finally, we join the code+state together to create $a1.
  (instance $a1 (instantiate $A_code
                  (import "__wizer_state" $a1_state_instance)))

  ;; State module for $a2. Global is initialized to 2 since $a2's `f`
  ;; function was called twice in the initialization.
  (module $a2_state_module
    (global (export "__wizer_global_0" (mut i32) (i32.const 2))))

  ;; The state instance for $a2.
  (instance $a2_state_instance (instantiate $a2_state_module))

  ;; Finally, we join the code+state together to create $a2.
  (instance $a2 (instantiate $A_code
                  (import "__wizer_state" $a2_state_instance)))

  ;; Initialization function removed.
)
```

Using this code splitting technique allows us to avoid unnecessary duplication
for each instantiation. The only bits that are duplicated are the things that
are inherently different across instantiations: the instantiation's internal
state.

The reason we don't allow importing and exporting modules within the bundle is
that two different modules that have the same module type signature could have
two different sets of internal, not-exported state. This throws a wrench in the
instrumentation pass, which needs to force export all internal state, and in
this case could make the modules have incompatible type signatures, so they
couldn't both be imported by the same module anymore. That, in turn, would force
us to duplicate and specialize modules that import other modules for each
instantiation. This is do-able, but requires significant additional engineering
work. Therefore, this feature is left for some time in the future.

As a final note, adding support for module linking required pretty much a full
rewrite of Wizer. It no longer just parses the Wasm section by section, tweaking
it in place. Instead, there is an initial "parse" phase that creates a
`ModuleInfo` tree that serves as an AST. Our subsequent passes -- the
instrumentation and rewriting passes -- process the `ModuleInfo` tree rather
than reparsing the input Wasm and tweaking it directly.

This pull request also adds a fuzz target for Wizer, to build confidence that
its implementation is still correct, even though it has become significantly
more complex than it used to be. This fuzz target checks that we get the same
result whether we

1. Instantiate the input Wasm module
2. Call the initialization function
3. Call the main function

or

1. Instantiate, initialize, and snapshot the Wasm module with Wizer
2. Instantiate the snapshot
4. Call the instantiated snapshot's main function

When checking that we get the same result, we don't just consider the main
function's results: we also consider memories and globals.

I've been running this locally for a couple days and, while there was an initial
flurry of failures and panics, it's been a while now since it fell over. I think
module linking support is in a good enough place where we can land it and
continue to bug fix in tree as we find new failures.

---------------------------------------------------------------------------------------------------------

@cfallin I'm flagging you for review because you're probably the person most familiar with Wizer's codebase other than me.

@alexcrichton I'm also flagging you for review because you're familiar with module linking and its implementation.

+cc @lukewagner as a general heads up.