### PR TITLE
Fix a bug with data segments at the end of memory

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -106,11 +106,10 @@ fn snapshot_memories<'a>(instance: &wasmtime::Instance) -> (Vec<u32>, Vec<DataSe
                     Some(i) => i,
                 };
                 start += nonzero;
-                let zero = memory[start..page_end]
+                let end = memory[start..page_end]
                     .iter()
                     .position(|byte| *byte == 0)
-                    .unwrap_or(page_end);
-                let end = start + zero;
+                    .map_or(page_end, |zero| start + zero);
                 segments.push(DataSegment {
                     memory_index,
                     offset: start as u32,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -713,6 +713,31 @@ fn rust_regex() -> anyhow::Result<()> {
 }
 
 #[test]
+fn data_segment_at_end_of_memory() -> anyhow::Result<()> {
+    // Test that we properly synthesize data segments for data at the end of
+    // memory.
+    run_wat(
+        &[],
+        42,
+        r#"
+(module
+  (memory 1)
+  (func (export "wizer.initialize")
+    ;; Store 42 to the last byte in memory.
+    i32.const 0
+    i32.const 42
+    i32.store8 offset=65535
+  )
+  (func (export "run") (result i32)
+    i32.const 0
+    i32.load8_u offset=65535
+  )
+)
+"#,
+    )
+}
+
+#[test]
 fn rename_functions() -> anyhow::Result<()> {
     let wat = r#"
 (module


### PR DESCRIPTION
Was accidentally adding a page offset to the end of the page and getting an out of bounds index when there was nonzero data at the very end of memory.