### PR TITLE
Avoid accidental quadratic behavior when removing excess data segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "wizer"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "cap-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wizer"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wizer"
-version = "1.3.2"
+version = "1.3.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,5 +1,5 @@
 use rayon::iter::{IntoParallelIterator, ParallelExtend, ParallelIterator};
-use std::{collections::BinaryHeap, convert::TryFrom};
+use std::convert::TryFrom;
 
 const WASM_PAGE_SIZE: u32 = 65_536;
 
@@ -203,62 +203,67 @@ fn snapshot_memories<'a>(instance: &wasmtime::Instance) -> (Vec<u32>, Vec<DataSe
         a.data = merged_data;
     }
 
-    // Engines apply a limit on how many segments a module may contain, and
-    // Wizer can run afoul of it. In this case, we need to merge data segments
-    // together until our number of data segments fits within the limit.
-    if merged_data_segments.len() >= MAX_DATA_SEGMENTS {
-        // We need to remove `excess` data segments. Find the `excess` smallest
-        // gaps between the start of one segment and the next. We will merge
-        // these segments together. Because they are the smallest gaps, this
-        // will bloat the size of our data segment the least.
-        let excess = merged_data_segments.len() - MAX_DATA_SEGMENTS;
-
-        #[derive(Clone, Copy, PartialEq, Eq)]
-        struct GapIndex {
-            gap: u32,
-            index: usize,
-        }
-        impl Ord for GapIndex {
-            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-                // NB: Bigger gaps first.
-                other
-                    .gap
-                    .cmp(&self.gap)
-                    .then_with(|| self.index.cmp(&other.index))
-            }
-        }
-        impl PartialOrd for GapIndex {
-            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                Some(self.cmp(other))
-            }
-        }
-
-        let mut smallest_gaps = BinaryHeap::<GapIndex>::with_capacity(excess + 1);
-        for (i, w) in merged_data_segments.windows(2).enumerate() {
-            debug_assert!(smallest_gaps.len() <= excess);
-            let gap = w[0].gap(&w[1]);
-            smallest_gaps.push(GapIndex { gap, index: i });
-            if smallest_gaps.len() > excess {
-                let entry = smallest_gaps.pop();
-                debug_assert!(entry.unwrap().gap >= gap);
-                debug_assert_eq!(smallest_gaps.len(), excess);
-            }
-        }
-
-        // Now merge the chosen segments together in reverse order so that
-        // merging two segments doesn't mess up the index of the next segments
-        // we will to merge.
-        let mut indices: Vec<_> = smallest_gaps.into_iter().map(|g| g.index).collect();
-        indices.sort_unstable_by(|a, b| a.cmp(b).reverse());
-        for i in indices {
-            let merged_data =
-                unsafe { merged_data_segments[i].merge(&merged_data_segments[i + 1]) };
-            merged_data_segments[i].data = merged_data;
-            merged_data_segments.remove(i + 1);
-        }
-    }
+    remove_excess_segments(&mut merged_data_segments);
 
     (memory_mins, merged_data_segments)
+}
+
+/// Engines apply a limit on how many segments a module may contain, and Wizer
+/// can run afoul of it. When that happens, we need to merge data segments
+/// together until our number of data segments fits within the limit.
+fn remove_excess_segments(merged_data_segments: &mut Vec<DataSegment<'_>>) {
+    if merged_data_segments.len() < MAX_DATA_SEGMENTS {
+        return;
+    }
+
+    // We need to remove `excess` number of data segments.
+    let excess = merged_data_segments.len() - MAX_DATA_SEGMENTS;
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    struct GapIndex {
+        gap: u32,
+        // Use a `u32` instead of `usize` to fit `GapIndex` within a word on
+        // 64-bit systems, using less memory.
+        index: u32,
+    }
+
+    // Find the gaps between the start of one segment and the next (if they are
+    // both in the same memory). We will merge the `excess` segments with the
+    // smallest gaps together. Because they are the smallest gaps, this will
+    // bloat the size of our data segment the least.
+    let mut smallest_gaps = Vec::with_capacity(merged_data_segments.len() - 1);
+    for (index, w) in merged_data_segments.windows(2).enumerate() {
+        if w[0].memory_index != w[1].memory_index {
+            continue;
+        }
+        let gap = w[0].gap(&w[1]);
+        let index = u32::try_from(index).unwrap();
+        smallest_gaps.push(GapIndex { gap, index });
+    }
+    smallest_gaps.sort_unstable_by_key(|g| g.gap);
+    smallest_gaps.truncate(excess);
+
+    // Now merge the chosen segments together in reverse index order so that
+    // merging two segments doesn't mess up the index of the next segments we
+    // will to merge.
+    smallest_gaps.sort_unstable_by(|a, b| a.index.cmp(&b.index).reverse());
+    for GapIndex { index, .. } in smallest_gaps {
+        let index = usize::try_from(index).unwrap();
+        let merged_data =
+            unsafe { merged_data_segments[index].merge(&merged_data_segments[index + 1]) };
+        merged_data_segments[index].data = merged_data;
+
+        // Okay to use `swap_remove` here because, even though it makes
+        // `merged_data_segments` unsorted, the segments are still sorted within
+        // the range `0..index` and future iterations will only operate within
+        // that subregion because we are iterating over largest to smallest
+        // indices.
+        merged_data_segments.swap_remove(index + 1);
+    }
+
+    // Finally, sort the data segments again so that our output is
+    // deterministic.
+    merged_data_segments.sort_by_key(|s| (s.memory_index, s.offset));
 }
 
 fn snapshot_instantiations<'a>(


### PR DESCRIPTION
Well, not really "accidental" in that I knew it was there, but I thought it
wouldn't matter in practice. Turns out it does, and removing many M elements
from a large N vector is, indeed, slow. Luckily, we can use `swap_remove` in
this case, which is O(1).