### PR TITLE
Publish binary releases of the `wizer` CLI tool

### DIFF
--- a/.github/actions/github-release/Dockerfile
+++ b/.github/actions/github-release/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:slim
+
+COPY . /action
+WORKDIR /action
+
+RUN npm install --production
+
+ENTRYPOINT ["node", "/action/main.js"]

--- a/.github/actions/github-release/README.md
+++ b/.github/actions/github-release/README.md
@@ -1,0 +1,18 @@
+# github-release
+
+An action used to publish GitHub releases for `wizer`, copied from Wasmtime's CI setup.
+
+As of the time of this writing there's a few actions floating around which
+perform github releases but they all tend to have their set of drawbacks.
+Additionally nothing handles deleting releases which we need for our rolling
+`dev` release.
+
+To handle all this this action rolls-its-own implementation using the
+actions/toolkit repository and packages published there. These run in a Docker
+container and take various inputs to orchestrate the release from the build.
+
+More comments can be found in `main.js`.
+
+Testing this is really hard. If you want to try though run `npm install` and
+then `node main.js`. You'll have to configure a bunch of env vars though to get
+anything reasonably working.

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -1,0 +1,15 @@
+name: 'Wizer github releases'
+description: 'Wizer github releases'
+inputs:
+  token:
+    description: ''
+    required: true
+  name:
+    description: ''
+    required: true
+  files:
+    description: ''
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/github-release/main.js
+++ b/.github/actions/github-release/main.js
@@ -1,0 +1,117 @@
+const core = require('@actions/core');
+const path = require("path");
+const fs = require("fs");
+const github = require('@actions/github');
+const glob = require('glob');
+
+function sleep(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
+async function runOnce() {
+  // Load all our inputs and env vars. Note that `getInput` reads from `INPUT_*`
+  const files = core.getInput('files');
+  const name = core.getInput('name');
+  const token = core.getInput('token');
+  const slug = process.env.GITHUB_REPOSITORY;
+  const owner = slug.split('/')[0];
+  const repo = slug.split('/')[1];
+  const sha = process.env.GITHUB_SHA;
+
+  core.info(`files: ${files}`);
+  core.info(`name: ${name}`);
+  core.info(`token: ${token}`);
+
+  const octokit = new github.GitHub(token);
+
+  // Delete the previous release since we can't overwrite one. This may happen
+  // due to retrying an upload or it may happen because we're doing the dev
+  // release.
+  const releases = await octokit.paginate("GET /repos/:owner/:repo/releases", { owner, repo });
+  for (const release of releases) {
+    if (release.tag_name !== name) {
+      continue;
+    }
+    const release_id = release.id;
+    core.info(`deleting release ${release_id}`);
+    await octokit.repos.deleteRelease({ owner, repo, release_id });
+  }
+
+  // We also need to update the `dev` tag while we're at it on the `dev` branch.
+  if (name == 'dev') {
+    try {
+      core.info(`updating dev tag`);
+      await octokit.git.updateRef({
+          owner,
+          repo,
+          ref: 'tags/dev',
+          sha,
+          force: true,
+      });
+    } catch (e) {
+      console.log("ERROR: ", JSON.stringify(e, null, 2));
+      core.info(`creating dev tag`);
+      await octokit.git.createTag({
+        owner,
+        repo,
+        tag: 'dev',
+        message: 'dev release',
+        object: sha,
+        type: 'commit',
+      });
+    }
+  }
+
+  // Creates an official GitHub release for this `tag`, and if this is `dev`
+  // then we know that from the previous block this should be a fresh release.
+  core.info(`creating a release`);
+  const release = await octokit.repos.createRelease({
+    owner,
+    repo,
+    tag_name: name,
+    prerelease: name === 'dev',
+  });
+
+  // Upload all the relevant assets for this release as just general blobs.
+  for (const file of glob.sync(files)) {
+    const size = fs.statSync(file).size;
+    core.info(`upload ${file}`);
+    await octokit.repos.uploadReleaseAsset({
+      data: fs.createReadStream(file),
+      headers: { 'content-length': size, 'content-type': 'application/octet-stream' },
+      name: path.basename(file),
+      url: release.data.upload_url,
+    });
+  }
+}
+
+async function run() {
+  const retries = 10;
+  for (let i = 0; i < retries; i++) {
+    try {
+      await runOnce();
+      break;
+    } catch (e) {
+      if (i === retries - 1)
+        throw e;
+      logError(e);
+      console.log("RETRYING after 10s");
+      await sleep(10000)
+    }
+  }
+}
+
+function logError(e) {
+  console.log("ERROR: ", e.message);
+  try {
+    console.log(JSON.stringify(e, null, 2));
+  } catch (e) {
+    // ignore json errors for now
+  }
+  console.log(e.stack);
+}
+
+run().catch(err => {
+  logError(err);
+  core.setFailed(err.message);
+});

--- a/.github/actions/github-release/package.json
+++ b/.github/actions/github-release/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wizer-github-release",
+  "version": "0.0.0",
+  "main": "main.js",
+  "dependencies": {
+    "@actions/core": "^1.0.0",
+    "@actions/github": "^1.0.0",
+    "glob": "^7.1.5"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+        - build: x86_64-linux
+          os: ubuntu-latest
+        - build: x86_64-macos
+          os: macos-latest
+        - build: x86_64-windows
+          os: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build
@@ -20,6 +29,22 @@ jobs:
       run: cargo test --verbose
     - name: Checking benches
       run : cargo check --benches
+    - name: Build release binary
+      run: cargo build --release --bin wizer --features="env_logger structopt"
+
+    - name: Create dist
+      run: mkdir dist
+
+    # Move binaries to dist folder
+    - run: cp target/release/wizer dist
+      if: matrix.os != 'windows-latest' && matrix.target == ''
+    - run: cp target/release/wizer.exe dist
+      if: matrix.build == 'x86_64-windows'
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: bins-${{ matrix.build }}
+        path: dist
 
   rustfmt:
     runs-on: ubuntu-latest
@@ -29,3 +54,66 @@ jobs:
     - run: rustup default stable
     - run: rustup component add rustfmt
     - run: cargo fmt --all -- --check
+
+
+  # Consumes all published artifacts from all the previous build steps, creates
+  # a bunch of tarballs for all of them, and then publishes the tarballs
+  # themselves as an artifact (for inspection) and then optionally creates
+  # github releases and/or tags for pushes.
+  publish:
+    name: Publish
+    needs: [build, rustfmt]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Download all the artifacts that we'll be publishing. Should keep an eye on
+    # the `download-artifact` repository to see if we can ever get something
+    # like "download all artifacts" or "download this list of artifacts"
+    - name: Download x86_64 macOS binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: bins-x86_64-macos
+    - name: Download x86_64 Linux binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: bins-x86_64-linux
+    - name: Download x86_64 Windows binaries
+      uses: actions/download-artifact@v1
+      with:
+        name: bins-x86_64-windows
+
+    - name: Calculate tag name
+      run: |
+        name=dev
+        if [[ $GITHUB_REF == refs/tags/v* ]]; then
+          name=${GITHUB_REF:10}
+        fi
+        echo ::set-output name=val::$name
+        echo TAG=$name >> $GITHUB_ENV
+      id: tagname
+
+    # Assemble all the build artifacts into tarballs and zip archives.
+    - name: Assemble tarballs
+      run: |
+        ./ci/build-tarballs.sh x86_64-linux
+        ./ci/build-tarballs.sh x86_64-macos
+        ./ci/build-tarballs.sh x86_64-windows .exe
+
+    # Upload all assembled tarballs as an artifact of the github action run, so
+    # that way even PRs can inspect the output.
+    - uses: actions/upload-artifact@v1
+      with:
+        name: tarballs
+        path: dist
+
+    # ... and if this was an actual push (tag or `main`) then we publish a
+    # new release. This'll automatically publish a tag release or update `dev`
+    # with this `sha`
+    - name: Publish Release
+      uses: ./.github/actions/github-release
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+      with:
+        files: "dist/*"
+        name: ${{ steps.tagname.outputs.val }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# A small shell script invoked from CI on the final Linux builder which actually
+# assembles the release artifacts for a particular platform. This will take the
+# binary artifacts of previous builders and create associated tarballs to
+# publish to GitHub.
+#
+# The first argument of this is the "platform" name to put into the tarball, and
+# the second argument is the name of the github actions platform which is where
+# we source binaries from. The final third argument is ".exe" on Windows to
+# handle executable extensions right.
+#
+# Usage: build-tarballs.sh PLATFORM [.exe]
+
+# where PLATFORM is e.g. x86_64-linux, aarch64-linux, ...
+
+set -ex
+
+platform=$1
+exe=$2
+
+rm -rf tmp
+mkdir tmp
+mkdir -p dist
+
+mktarball() {
+  dir=$1
+  if [ "$exe" = "" ]; then
+    tar cJf dist/$dir.tar.xz -C tmp $dir
+  else
+    (cd tmp && zip -r ../dist/$dir.zip $dir)
+  fi
+}
+
+# Create the main tarball of binaries
+bin_pkgname=wizer-$TAG-$platform
+mkdir tmp/$bin_pkgname
+cp README.md tmp/$bin_pkgname
+mv bins-$platform/wizer$exe tmp/$bin_pkgname
+chmod +x tmp/$bin_pkgname/wizer$exe
+mktarball $bin_pkgname


### PR DESCRIPTION
This adds automation to publish releases for Linux, macOS, and Windows, all 64bit. Same as for Wasmtime, releases are published under the `dev` tag whenever a PR is merged, and whenever a commit is tagged.

This is based on what Wasmtime used to do and what [fastly/js-compute-runtime]() still does. There's quite a bit of duplication of project names and the likes going on, which would be nice to clean up, but I'd expect that to take meaningful amounts of time that I can't currently spend :(