### PR TITLE
Enable bulk memory in wasmtime config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ impl Wizer {
         config.wasm_reference_types(false);
         config.wasm_simd(false);
         config.wasm_threads(false);
-        config.wasm_bulk_memory(false);
+        config.wasm_bulk_memory(true);
 
         Ok(config)
     }


### PR DESCRIPTION
Sure, proper support for bulk memory takes more work to handle passive/active segments properly. For our use case which only involves `memory.copy`/`memory.fill` opcodes, this is a workaround to prevent `wizer` from panicking.