### PR TITLE
Bump to 1.3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
         name: bins-${{ matrix.build }}
         path: dist
 
+  check_fuzz:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: cargo install cargo-fuzz
+    - run: cargo fuzz build --dev -s none
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "wizer"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "anyhow",
  "cap-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wizer"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wizer"
-version = "1.3.4"
+version = "1.3.5"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This *might* run into the rustix+nightly bug, in which case we will have to pin to an older nightly Rust. Let's see.