### PR TITLE
Add an option to keep init-func after initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,9 +143,11 @@ pub struct Wizer {
     )]
     inherit_env: Option<bool>,
 
-    /// After initialization, should `init_func` be removed from the module?
+    /// After initialization, should the Wasm module still export the
+    /// initialization function?
     ///
-    /// This is false by default.
+    /// This is `false` by default, meaning that the initialization function is
+    /// no longer exported from the Wasm module.
     #[cfg_attr(
         feature = "structopt",
         structopt(long = "keep-init-func", value_name = "true|false")
@@ -305,9 +307,11 @@ impl Wizer {
         self
     }
 
-    /// After initialization, should `init_func` be removed from the module?
+    /// After initialization, should the Wasm module still export the
+    /// initialization function?
     ///
-    /// Defaults to `false`.
+    /// This is `false` by default, meaning that the initialization function is
+    /// no longer exported from the Wasm module.
     pub fn keep_init_func(&mut self, keep: bool) -> &mut Self {
         self.keep_init_func = Some(keep);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use wasmtime_wasi::WasiCtx;
 
 const DEFAULT_INHERIT_STDIO: bool = true;
 const DEFAULT_INHERIT_ENV: bool = false;
+const DEFAULT_KEEP_INIT_FUNC: bool = false;
 const DEFAULT_WASM_MULTI_VALUE: bool = true;
 const DEFAULT_WASM_MULTI_MEMORY: bool = true;
 const DEFAULT_WASM_MODULE_LINKING: bool = false;
@@ -142,6 +143,15 @@ pub struct Wizer {
     )]
     inherit_env: Option<bool>,
 
+    /// After initialization, should `init_func` be removed from the module?
+    ///
+    /// This is false by default.
+    #[cfg_attr(
+        feature = "structopt",
+        structopt(long = "keep-init-func", value_name = "true|false")
+    )]
+    keep_init_func: Option<bool>,
+
     /// When using WASI during initialization, which file system directories
     /// should be made available?
     ///
@@ -235,6 +245,7 @@ impl Wizer {
             allow_wasi: false,
             inherit_stdio: None,
             inherit_env: None,
+            keep_init_func: None,
             dirs: vec![],
             map_dirs: vec![],
             wasm_multi_memory: None,
@@ -291,6 +302,14 @@ impl Wizer {
     /// Defaults to `false`.
     pub fn inherit_env(&mut self, inherit: bool) -> &mut Self {
         self.inherit_env = Some(inherit);
+        self
+    }
+
+    /// After initialization, should `init_func` be removed from the module?
+    ///
+    /// Defaults to `false`.
+    pub fn keep_init_func(&mut self, keep: bool) -> &mut Self {
+        self.keep_init_func = Some(keep);
         self
     }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -8,7 +8,7 @@ use crate::{
         Module, ModuleContext,
     },
     snapshot::Snapshot,
-    translate, FuncRenames, Wizer,
+    translate, FuncRenames, Wizer, DEFAULT_KEEP_INIT_FUNC,
 };
 use renumbering::Renumbering;
 use std::{convert::TryFrom, iter};
@@ -137,8 +137,9 @@ impl Wizer {
                 s if s.id == SectionId::Export.into() => {
                     let mut exports = wasm_encoder::ExportSection::new();
                     for export in module.exports(cx) {
-                        if export.field == self.init_func
-                            || (has_wasi_initialize && export.field == "_initialize")
+                        if !self.keep_init_func.unwrap_or(DEFAULT_KEEP_INIT_FUNC)
+                            && (export.field == self.init_func
+                                || (has_wasi_initialize && export.field == "_initialize"))
                         {
                             continue;
                         }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -422,7 +422,10 @@ impl Wizer {
         let mut aliases = wasm_encoder::AliasSection::new();
         let mut exports = wasm_encoder::ExportSection::new();
         for exp in cx.root().exports(cx) {
-            if exp.field == self.init_func || (has_wasi_initialize && exp.field == "_initialize") {
+            if !self.keep_init_func.unwrap_or(DEFAULT_KEEP_INIT_FUNC)
+                && (exp.field == self.init_func
+                    || (has_wasi_initialize && exp.field == "_initialize"))
+            {
                 continue;
             }
 


### PR DESCRIPTION
It would be useful to keep the init-func after initialization when applying wizer multiple times.
My use case is packing files into binary in init-func, and it can pack multiple times in theory.