### PR TITLE
Update cap-std to v0.24.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,30 +162,10 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71f5b22f0dc04ed3404bfae102654978bfd425c5568851a89eb4d4b8f58e9590"
 dependencies = [
- "cap-primitives 0.24.1",
- "cap-std 0.24.1",
- "io-lifetimes 0.5.3",
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
  "winapi",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5998b8b3a49736500aec3c123fa3f6f605a125b41a6df725e6b7c924a612ab4"
-dependencies = [
- "ambient-authority",
- "errno",
- "fs-set-times 0.13.1",
- "io-extras 0.11.2",
- "io-lifetimes 0.3.3",
- "ipnet",
- "maybe-owned",
- "rustc_version",
- "rustix 0.26.2",
- "winapi",
- "winapi-util",
- "winx 0.29.1",
 ]
 
 [[package]]
@@ -196,15 +176,15 @@ checksum = "defd283f080043a702c362203c2646a4e0a2fff99baede1eea1416239f0af220"
 dependencies = [
  "ambient-authority",
  "errno",
- "fs-set-times 0.15.0",
- "io-extras 0.13.2",
- "io-lifetimes 0.5.3",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 0.33.2",
+ "rustix",
  "winapi",
  "winapi-util",
- "winx 0.31.0",
+ "winx",
 ]
 
 [[package]]
@@ -219,29 +199,15 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.21.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811de89a7ede4ba32f2b75fe5c668a534da24942d81c081248a9d2843ebd517d"
+checksum = "3430d1b5ba78fa381eb227525578d2b85d77b42ff49be85d1e72a94f305e603c"
 dependencies = [
- "cap-primitives 0.21.1",
- "io-extras 0.11.2",
- "io-lifetimes 0.3.3",
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
  "ipnet",
- "rustc_version",
- "rustix 0.26.2",
-]
-
-[[package]]
-name = "cap-std"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbe56c8ed4cdf8360deb80dcced538968d3bac45e71befee65e95a0e262caf2"
-dependencies = [
- "cap-primitives 0.24.1",
- "io-extras 0.13.2",
- "io-lifetimes 0.5.3",
- "ipnet",
- "rustix 0.33.2",
+ "rustix",
 ]
 
 [[package]]
@@ -250,10 +216,10 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a34e5a4375b768b3acaec25dd7b53bcc15c801258c43a0ef2da2027f2028e46"
 dependencies = [
- "cap-primitives 0.24.1",
+ "cap-primitives",
  "once_cell",
- "rustix 0.33.2",
- "winx 0.31.0",
+ "rustix",
+ "winx",
 ]
 
 [[package]]
@@ -641,23 +607,12 @@ dependencies = [
 
 [[package]]
 name = "fs-set-times"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa838950e8e36a567ce96a945c303e88d9916ff97df27c315a0d263a72bd816f"
-dependencies = [
- "io-lifetimes 0.3.3",
- "rustix 0.26.2",
- "winapi",
-]
-
-[[package]]
-name = "fs-set-times"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
 dependencies = [
- "io-lifetimes 0.5.3",
- "rustix 0.33.2",
+ "io-lifetimes",
+ "rustix",
  "winapi",
 ]
 
@@ -772,32 +727,11 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1d9a66d8b0312e3601a04a2dcf8f0ddd873319560ddeabe2110fa1e5af781a"
-dependencies = [
- "io-lifetimes 0.3.3",
- "rustc_version",
- "winapi",
-]
-
-[[package]]
-name = "io-extras"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c937cc9891c12eaa8c63ad347e4a288364b1328b924886970b47a14ab8f8f8"
 dependencies = [
- "io-lifetimes 0.5.3",
- "winapi",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278e90d6f8a6c76a8334b336e306efa3c5f2b604048cbfd486d6f49878e3af14"
-dependencies = [
- "rustc_version",
+ "io-lifetimes",
  "winapi",
 ]
 
@@ -824,8 +758,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c89a757e762896bdbdfadf2860d0f8b0cea5e363d8cf3e7bdfeb63d1d976352"
 dependencies = [
  "hermit-abi 0.2.0",
- "io-lifetimes 0.5.3",
- "rustix 0.33.2",
+ "io-lifetimes",
+ "rustix",
  "winapi",
 ]
 
@@ -902,12 +836,6 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.0.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1297,33 +1225,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c44018277ec7195538f5631b90def7ad975bb46370cb0f4eff4012de9333f8"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 0.3.3",
- "itoa 0.4.8",
- "libc",
- "linux-raw-sys 0.0.36",
- "once_cell",
- "rustc_version",
- "winapi",
-]
-
-[[package]]
-name = "rustix"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db890a96e64911e67fa84e58ce061a40a6a65c231e5fad20b190933f8991a27c"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 0.5.3",
+ "io-lifetimes",
  "itoa 1.0.1",
  "libc",
- "linux-raw-sys 0.0.40",
+ "linux-raw-sys",
  "once_cell",
  "winapi",
 ]
@@ -1492,11 +1403,11 @@ dependencies = [
  "atty",
  "bitflags",
  "cap-fs-ext",
- "cap-std 0.24.1",
- "io-lifetimes 0.5.3",
- "rustix 0.33.2",
+ "cap-std",
+ "io-lifetimes",
+ "rustix",
  "winapi",
- "winx 0.31.0",
+ "winx",
 ]
 
 [[package]]
@@ -1667,14 +1578,14 @@ dependencies = [
  "async-trait",
  "cap-fs-ext",
  "cap-rand",
- "cap-std 0.24.1",
+ "cap-std",
  "cap-time-ext",
- "fs-set-times 0.15.0",
- "io-extras 0.13.2",
- "io-lifetimes 0.5.3",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
  "is-terminal",
  "lazy_static",
- "rustix 0.33.2",
+ "rustix",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -1690,8 +1601,8 @@ dependencies = [
  "anyhow",
  "bitflags",
  "cap-rand",
- "cap-std 0.24.1",
- "rustix 0.33.2",
+ "cap-std",
+ "rustix",
  "thiserror",
  "tracing",
  "wiggle",
@@ -1856,7 +1767,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.33.2",
+ "rustix",
  "serde",
  "sha2",
  "toml",
@@ -1913,7 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e285306aa274d85a22753bef826226e1cc473bac0b541523f46dccf80751cc"
 dependencies = [
  "cc",
- "rustix 0.33.2",
+ "rustix",
  "winapi",
 ]
 
@@ -1933,7 +1844,7 @@ dependencies = [
  "object 0.27.1",
  "region",
  "rustc-demangle",
- "rustix 0.33.2",
+ "rustix",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -1961,7 +1872,7 @@ dependencies = [
  "more-asserts",
  "rand",
  "region",
- "rustix 0.33.2",
+ "rustix",
  "thiserror",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -2105,23 +2016,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecd175b4077107a91bb6bbb34aa9a691d8b45314791776f78b63a1cb8a08928"
-dependencies = [
- "bitflags",
- "io-lifetimes 0.3.3",
- "winapi",
-]
-
-[[package]]
-name = "winx"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d5973cb8cd94a77d03ad7e23bbe14889cb29805da1cec0e4aff75e21aebded"
 dependencies = [
  "bitflags",
- "io-lifetimes 0.5.3",
+ "io-lifetimes",
  "winapi",
 ]
 
@@ -2142,7 +2042,7 @@ name = "wizer"
 version = "1.3.5"
 dependencies = [
  "anyhow",
- "cap-std 0.21.1",
+ "cap-std",
  "criterion",
  "env_logger 0.8.4",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ harness = false
 
 [dependencies]
 anyhow = "1.0.38"
-cap-std = "0.21.1"
+cap-std = "0.24.2"
 env_logger = { version = "0.8.2", optional = true }
 log = "0.4.14"
 rayon = "1.5.0"


### PR DESCRIPTION
This change allows Wizer to be built using recent nightly versions of rust.

The version of `wasmtime` being used is recent enough, but the version of `cap-std` still depended on an older version of `rustix`