### PR TITLE
implement partial bulk memory support

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -84,7 +84,12 @@ pub(crate) fn parse<'a>(full_wasm: &'a [u8]) -> anyhow::Result<ModuleContext<'a>
                 elems.range(),
                 full_wasm,
             ),
-            DataCountSection { .. } => unreachable!("validation rejects bulk memory"),
+            DataCountSection { range, .. } => stack.top_mut().module.add_raw_section(
+                &mut cx,
+                SectionId::DataCount,
+                range,
+                full_wasm,
+            ),
             DataSection(data) => stack.top_mut().module.add_raw_section(
                 &mut cx,
                 SectionId::Data,


### PR DESCRIPTION
This is an expanded version of #37 which explicitly supports `memory.copy`,
`memory.fill`, and `memory.init` but still rejects modules which use any other
bulk memory operations.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>