### PR TITLE
Update wizer.h to reference __main_void or __original_main as needed

### DIFF
--- a/examples/cpp/Makefile
+++ b/examples/cpp/Makefile
@@ -1,7 +1,7 @@
 CXX := /opt/wasi-sdk/bin/clang++
 CXXFLAGS := -O2 -I ../../include/
 WIZER := ../../target/release/wizer
-WASMTIME := wasmtime
+WASMTIME ?= wasmtime
 
 .PHONY: all
 all: main_initialized.wasm
@@ -10,7 +10,7 @@ main.wasm: main.cpp
 	$(CXX) $(CXXFLAGS) -o $@ $^
 
 main_initialized.wasm: main.wasm
-	$(WIZER) --allow-wasi -r _start=wizer.resume -o $@ $^
+	$(WIZER) --allow-wasi --wasm-bulk-memory=true -r _start=wizer.resume -o $@ $^
 
 .PHONY: test
 test: main_initialized.wasm

--- a/include/wizer.h
+++ b/include/wizer.h
@@ -15,6 +15,27 @@
 #define __WIZER_EXTERN_C extern
 #endif
 
+#ifdef __clang_major__
+// wasi-sdk-16 was the first wasi-sdk version that shipped with a version of
+// wasi-libc that did not include __original_main. However, wasi-sdk-15 shipped
+// with clang-14.0.0. To correctly identify the boundary where __original_main
+// no longer exists, we check for either clang-15+ or specifically clang-14.0.4.
+//
+// wasi-sdk-17 ships with clang-15.0.6
+// wasi-sdk-16 ships with clang-14.0.4
+#if __clang_major__ >= 15 || (__clang_major__ == 14 && __clang_patchlevel__ == 4)
+#define WIZER_MAIN_VOID __main_void
+#else
+#define WIZER_MAIN_VOID __original_main
+#endif
+#endif
+
+// We default to assuming that the compiler is new enough to provide
+// __main_void.
+#ifndef WIZER_MAIN_VOID
+#define WIZER_MAIN_VOID __main_void
+#endif
+
 /*
  * This macro inserts the exported functions necessary to allow Wizer to
  * pre-initialize a Wasm module.
@@ -63,7 +84,7 @@
 #define WIZER_INIT(init_func)                                                  \
     __WIZER_EXTERN_C void __wasm_call_ctors();                                 \
     __WIZER_EXTERN_C void __wasm_call_dtors();                                 \
-    __WIZER_EXTERN_C int __original_main();                                    \
+    __WIZER_EXTERN_C int WIZER_MAIN_VOID();                                    \
     /* This function's export name `wizer.initialize` is specially          */ \
     /* recognized by Wizer. It is the direct entry point for pre-init.      */ \
     __attribute__((export_name("wizer.initialize"))) void                      \
@@ -80,14 +101,14 @@
     /* This function replaces `_start` (the WASI-specified entry point) in  */ \
     /* the pre-initialized Wasm module.                                     */ \
     __attribute__((export_name("wizer.resume"))) void __wizer_resume() {       \
-        /* `__original_main()` is defined by the WASI SDK toolchain due to  */ \
+        /* `__main_void()` is defined by the WASI SDK toolchain due to      */ \
         /* special semantics in C/C++ for the `main()` function, i.e., ito  */ \
         /* can either take argc/argv or not. It collects arguments using    */ \
         /* the appropriate WASI calls and then invokes the user program's   */ \
         /* `main()`. This may change in the future; when it does, we will   */ \
         /* coordinate with the WASI-SDK toolchain to implement this entry   */ \
         /* point in an alternate way. */                                       \
-        __original_main();                                                     \
+        WIZER_MAIN_VOID();                                                     \
         /* Because we are replacing `_start()`, we need to manually invoke  */ \
         /* destructors as well.                                             */ \
         __wasm_call_dtors();                                                   \


### PR DESCRIPTION
Use the clang version to detect the version of wasi-sdk we're linking with, so that we can determine if we should reference `__original_main` or `__main_void`.

cc @sunfishcode