### PR TITLE
Reduce the maximum number of data segments.

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4,8 +4,10 @@ use wasmtime::{AsContext, AsContextMut};
 
 const WASM_PAGE_SIZE: u64 = 65_536;
 
-/// The maximum number of data segments that most engines support.
-const MAX_DATA_SEGMENTS: usize = 100_000;
+/// The maximum number of data segments that we will emit. Most
+/// engines support more than this, but we want to leave some
+/// headroom.
+const MAX_DATA_SEGMENTS: usize = 10_000;
 
 /// A "snapshot" of Wasm state from its default value after having been initialized.
 pub struct Snapshot {


### PR DESCRIPTION
Fixes #70.

We've found that in some cases, Wizer can generate too many data segments, such that we hit tool or engine limits elsewhere. Beyond a reasonable number, many tiny data segments can also reduce in less efficient processing overall, as well. This PR alters the constant in Wizer's internal memory-snapshot generation to force coalescing of segments beyond a limit of 10k, rather than the current 100k.