### PR TITLE
Bump version to 1.6.1-beta

### DIFF
--- a/npm/wizer/package.json
+++ b/npm/wizer/package.json
@@ -1,11 +1,8 @@
 {
-  "name": "@bytecode-alliance/wizer",
-  "version": "1.6.0",
+  "name": "@bytecodealliance/wizer",
+  "version": "1.6.1-beta",
   "description": "The WebAssembly Pre-Initializer",
   "type": "module",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "version": "node ./update.js $npm_package_version"
   },

--- a/npm/wizer/update.js
+++ b/npm/wizer/update.js
@@ -117,7 +117,7 @@ export default location
 function packageJson(name, version, description, os, cpu) {
     version = version.startsWith('v') ? version.replace('v','') : version
     return JSON.stringify({
-        name: `@bytecode-alliance/${name}`,
+        name: `@bytecodealliance/${name}`,
         bin: {
             [name]: "wizer"
         },
@@ -129,8 +129,5 @@ function packageJson(name, version, description, os, cpu) {
         preferUnplugged: false,
         os: [os],
         cpu: [cpu],
-        publishConfig: {
-            access: "public"
-        },
     }, null, 4);
 }


### PR DESCRIPTION
Also this moves to `@bytecodealliance/wizer`. Version is suffixed `-beta` as we will only be updating on npm but not on crates.io.