### PR TITLE
fixup: release changes

### DIFF
--- a/npm/wizer/README.md
+++ b/npm/wizer/README.md
@@ -5,12 +5,12 @@
 ## API
 
 ```
-$ npm install --save @bytecode-alliance/wizer
+$ npm install --save @bytecodealliance/wizer
 ```
 
 ```js
 const execFile = require('child_process').execFile;
-const wizer = require('@bytecode-alliance/wizer');
+const wizer = require('@bytecodealliance/wizer');
 
 execFile(wizer, ['input.wasm', '-o', 'initialized.wasm'], (err, stdout) => {
 	console.log(stdout);

--- a/npm/wizer/package.json
+++ b/npm/wizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytecodealliance/wizer",
-  "version": "1.6.1-beta",
+  "version": "1.6.1-beta.2",
   "description": "The WebAssembly Pre-Initializer",
   "type": "module",
   "scripts": {
@@ -20,10 +20,10 @@
     "wizer": "./wizer.js"
   },
   "optionalDependencies": {
-    "@bytecode-alliance/wizer-darwin-arm64": "1.6.1-beta",
-    "@bytecode-alliance/wizer-darwin-x64": "1.6.1-beta",
-    "@bytecode-alliance/wizer-linux-x64": "1.6.1-beta",
-    "@bytecode-alliance/wizer-win32-x64": "1.6.1-beta"
+    "@bytecodealliance/wizer-darwin-arm64": "1.6.1-beta",
+    "@bytecodealliance/wizer-darwin-x64": "1.6.1-beta",
+    "@bytecodealliance/wizer-linux-x64": "1.6.1-beta",
+    "@bytecodealliance/wizer-win32-x64": "1.6.1-beta"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/npm/wizer/package.json
+++ b/npm/wizer/package.json
@@ -20,10 +20,10 @@
     "wizer": "./wizer.js"
   },
   "optionalDependencies": {
-    "@bytecode-alliance/wizer-darwin-arm64": "1.6.0",
-    "@bytecode-alliance/wizer-darwin-x64": "1.6.0",
-    "@bytecode-alliance/wizer-linux-x64": "1.6.0",
-    "@bytecode-alliance/wizer-win32-x64": "1.6.0"
+    "@bytecode-alliance/wizer-darwin-arm64": "1.6.1-beta",
+    "@bytecode-alliance/wizer-darwin-x64": "1.6.1-beta",
+    "@bytecode-alliance/wizer-linux-x64": "1.6.1-beta",
+    "@bytecode-alliance/wizer-win32-x64": "1.6.1-beta"
   },
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
https://www.npmjs.com/package/@bytecodealliance/wizer is now live.

I had to make a couple of edits during the release process that were missed out of the version bump.