### PR TITLE
Allow a preloaded module to be used by the wizened module.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,12 @@ pub struct Wizer {
     #[cfg_attr(feature = "structopt", structopt(long = "preload"))]
     preload: Option<String>,
 
+    /// Like `preload` above, but with the module contents provided,
+    /// rather than a filename. This is more useful for programmatic
+    /// use-cases where the embedding tool may also embed a Wasm module.
+    #[cfg_attr(feature = "structopt", structopt(skip))]
+    preload_bytes: Option<(String, Vec<u8>)>,
+
     #[cfg_attr(feature = "structopt", structopt(skip))]
     make_linker: Option<Rc<dyn Fn(&wasmtime::Engine) -> anyhow::Result<Linker>>>,
 
@@ -237,6 +243,7 @@ impl std::fmt::Debug for Wizer {
             func_renames,
             allow_wasi,
             preload,
+            preload_bytes,
             make_linker: _,
             inherit_stdio,
             inherit_env,
@@ -253,6 +260,7 @@ impl std::fmt::Debug for Wizer {
             .field("func_renames", &func_renames)
             .field("allow_wasi", &allow_wasi)
             .field("preload", &preload)
+            .field("preload_bytes", &preload_bytes)
             .field("make_linker", &"..")
             .field("inherit_stdio", &inherit_stdio)
             .field("inherit_env", &inherit_env)
@@ -316,6 +324,7 @@ impl Wizer {
             func_renames: vec![],
             allow_wasi: false,
             preload: None,
+            preload_bytes: None,
             make_linker: None,
             inherit_stdio: None,
             inherit_env: None,
@@ -363,6 +372,67 @@ impl Wizer {
             "Cannot use 'allow_wasi' with a custom linker"
         );
         self.allow_wasi = allow;
+        Ok(self)
+    }
+
+    /// Provide an additional preloaded module that is available to the
+    /// main module.
+    ///
+    /// This allows running a module that depends on imports from
+    /// another module. Note that the additional module's state is *not*
+    /// snapshotted, nor is its code included in the Wasm snapshot;
+    /// rather, it is assumed that the resulting snapshot Wasm will also
+    /// be executed with the same imports available.
+    ///
+    /// The main purpose of this option is to allow "stubs" for certain
+    /// intrinsics to be included, when these will be provided with
+    /// different implementations when running or further processing the
+    /// snapshot.
+    pub fn preload(
+        &mut self,
+        name_and_filename: Option<(&str, &str)>,
+    ) -> anyhow::Result<&mut Self> {
+        anyhow::ensure!(
+            self.make_linker.is_none(),
+            "Cannot use 'preload' with a custom linker"
+        );
+        if let Some((name, _)) = name_and_filename {
+            anyhow::ensure!(
+                !name.contains("="),
+                "Module name cannot contain an `=` character"
+            );
+        }
+        self.preload = name_and_filename.map(|(name, filename)| format!("{}={}", name, filename));
+        Ok(self)
+    }
+
+    /// Provide an additional preloaded module that is available to the
+    /// main module. Unlike `preload()`, this method takes an owned
+    /// vector of bytes as the module's actual content, rather than a
+    /// filename. As with `preload()`, the module may be in Wasm binary
+    /// format or in WAT text format.
+    ///
+    /// This allows running a module that depends on imports from
+    /// another module. Note that the additional module's state is *not*
+    /// snapshotted, nor is its code included in the Wasm snapshot;
+    /// rather, it is assumed that the resulting snapshot Wasm will also
+    /// be executed with the same imports available.
+    ///
+    /// The main purpose of this option is to allow "stubs" for certain
+    /// intrinsics to be included, when these will be provided with
+    /// different implementations when running or further processing the
+    /// snapshot.
+    ///
+    /// The argument is either `Some((module_name, bytes))` or `None`.
+    pub fn preload_bytes(
+        &mut self,
+        name_and_bytes: Option<(&str, Vec<u8>)>,
+    ) -> anyhow::Result<&mut Self> {
+        anyhow::ensure!(
+            self.make_linker.is_none(),
+            "Cannot use 'preload_bytes' with a custom linker"
+        );
+        self.preload_bytes = name_and_bytes.map(|(name, bytes)| (name.to_owned(), bytes));
         Ok(self)
     }
 
@@ -726,6 +796,25 @@ impl Wizer {
         Ok(Some(ctx.build()))
     }
 
+    /// Preload a module.
+    fn do_preload(
+        &self,
+        engine: &Engine,
+        store: &mut Store,
+        linker: &mut Linker,
+        name: &str,
+        content: &[u8],
+    ) -> anyhow::Result<()> {
+        let module =
+            wasmtime::Module::new(engine, content).context("failed to parse preload module")?;
+        let instance = wasmtime::Instance::new(&mut *store, &module, &[])
+            .context("failed to instantiate preload module")?;
+        linker
+            .instance(&mut *store, name, instance)
+            .context("failed to add preload's exports to linker")?;
+        Ok(())
+    }
+
     /// Instantiate the module and call its initialization function.
     fn initialize(
         &self,
@@ -750,19 +839,16 @@ impl Wizer {
         if let Some(preload) = &self.preload {
             if let Some((name, value)) = preload.split_once('=') {
                 let content = std::fs::read(value).context("failed to read preload module")?;
-                let module = wasmtime::Module::new(engine, content)
-                    .context("failed to parse preload module")?;
-                let instance = wasmtime::Instance::new(&mut *store, &module, &[])
-                    .context("failed to instantiate preload module")?;
-                linker
-                    .instance(&mut *store, name, instance)
-                    .context("failed to add preload's exports to linker")?;
+                self.do_preload(engine, &mut *store, &mut linker, &name[..], &content[..])?;
             } else {
                 anyhow::bail!(
                     "Bad preload option: {} (must be of form `name=file`)",
                     preload
                 );
             }
+        }
+        if let Some((name, bytes)) = &self.preload_bytes {
+            self.do_preload(engine, &mut *store, &mut linker, &name[..], &bytes[..])?;
         }
 
         dummy_imports(&mut *store, &module, &mut linker)?;

--- a/tests/preloads.rs
+++ b/tests/preloads.rs
@@ -1,0 +1,80 @@
+use anyhow::Result;
+use wat::parse_str as wat_to_wasm;
+use wizer::Wizer;
+
+const PRELOAD1: &'static str = r#"
+(module
+ (func (export "f") (param i32) (result i32)
+  local.get 0
+  i32.const 1
+  i32.add))
+  "#;
+
+const PRELOAD2: &'static str = r#"
+(module
+ (func (export "f") (param i32) (result i32)
+  local.get 0
+  i32.const 2
+  i32.add))
+  "#;
+
+fn run_with_preloads(args: &[wasmtime::Val], wat: &str) -> Result<wasmtime::Val> {
+    let wasm = wat_to_wasm(wat)?;
+    let mut w = Wizer::new();
+    w.preload_bytes("mod1", PRELOAD1.as_bytes().to_vec())?;
+    w.preload_bytes("mod2", PRELOAD2.as_bytes().to_vec())?;
+    let processed = w.run(&wasm)?;
+
+    let engine = wasmtime::Engine::default();
+    let mut store = wasmtime::Store::new(&engine, ());
+
+    let mod1 = wasmtime::Module::new(&engine, PRELOAD1.as_bytes())?;
+    let mod2 = wasmtime::Module::new(&engine, PRELOAD2.as_bytes())?;
+    let testmod = wasmtime::Module::new(&engine, &processed[..])?;
+
+    let mod1_inst = wasmtime::Instance::new(&mut store, &mod1, &[])?;
+    let mod2_inst = wasmtime::Instance::new(&mut store, &mod2, &[])?;
+    let mut linker = wasmtime::Linker::new(&engine);
+    linker.instance(&mut store, "mod1", mod1_inst)?;
+    linker.instance(&mut store, "mod2", mod2_inst)?;
+
+    let inst = linker.instantiate(&mut store, &testmod)?;
+    let run = inst
+        .get_func(&mut store, "run")
+        .ok_or_else(|| anyhow::anyhow!("no `run` function on test module"))?;
+    let mut returned = vec![wasmtime::Val::I32(0)];
+    run.call(&mut store, args, &mut returned)?;
+    Ok(returned[0].clone())
+}
+
+#[test]
+fn test_preloads() {
+    const WAT: &'static str = r#"
+    (module
+     (import "mod1" "f" (func $mod1f (param i32) (result i32)))
+     (import "mod2" "f" (func $mod2f (param i32) (result i32)))
+     (global $g1 (mut i32) (i32.const 0))
+     (global $g2 (mut i32) (i32.const 0))
+     (func (export "wizer.initialize")
+      i32.const 100
+      call $mod1f
+      global.set $g1
+      i32.const 100
+      call $mod2f
+      global.set $g2)
+     (func (export "run") (param i32 i32) (result i32)
+      local.get 0
+      call $mod1f
+      local.get 1
+      call $mod2f
+      i32.add
+      global.get $g1
+      global.get $g2
+      i32.add
+      i32.add))
+    "#;
+
+    let result =
+        run_with_preloads(&[wasmtime::Val::I32(200), wasmtime::Val::I32(201)], WAT).unwrap();
+    assert!(matches!(result, wasmtime::Val::I32(607)));
+}


### PR DESCRIPTION
This PR adds a `--preload` option to Wizer that allows the user to provide a second module (in addition to the module being snapshotted) whose exprts are available for import by the snapshotted module.

The preloaded module is not snapshotted, and is not linked or included in any way into the snapshot. Rather, it is assumed to contain intrinsics, stubs, helpers, or other stateless functions that are needed by the snapshotted module and that will also be available in its post-snapshot execution environment.

This option is useful for, e.g., implementing "intrinsics" for other Wasm-transform tools that are implemented as magic imports. These imports can be stubbed out during snapshotting, but preserved as calls to imports in the snapshot, to enable further processing.