### PR TITLE
Re-export Wasmtime crate to allow easier use with Wizer API.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ mod snapshot;
 mod stack_ext;
 mod translate;
 
+/// Re-export wasmtime so users can align with our version. This is
+/// especially useful when providing a custom Linker.
+pub use wasmtime;
+
 use anyhow::Context;
 use dummy::dummy_imports;
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
The Wizer API exposes several Wasmtime types, especially when using the functionality to provide a custom linker. It is thus useful to have a re-exported `wasmtime` to refer use when driving Wizer as a library, so versions do not need to be manually synchronized.