### PR TITLE
Bump to version 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "wizer"
-version = "1.6.1-beta.4"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "cap-std 0.24.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wizer"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wizer"
-version = "1.6.1-beta.4"
+version = "2.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Because Wasmtime is a public dep, and that dep has bumped since the last release, we need to do a major version bump.