### PR TITLE
Avoid duplicate call to _initialize with `-f=_initialize`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -866,6 +866,12 @@ impl Wizer {
                         f.call(&mut *store, ()).map_err(Into::into)
                     })
                     .context("calling the Reactor initialization function")?;
+
+                if self.init_func == "_initialize" && has_wasi_initialize {
+                    // Don't run `_initialize` twice if the it was explicitly
+                    // requested as the init function.
+                    return Ok((instance, has_wasi_initialize));
+                }
             }
         }
 


### PR DESCRIPTION
Hi,

I'm using wizer to pre-initialize reactor modules with `--init-func="_initialize"`. wasi-libc recently added a check against calling the reactor initializer multiple times (https://github.com/WebAssembly/wasi-libc/pull/388), which shows that wizer calls it twice in this case. (Once because the reactor initializer is automatically called and a second time because I'm setting it as the init function.) 

I think it's reasonable to simply skip the second call for `--init-func=_initialize`. :slightly_smiling_face: 