### PR TITLE
add prebuilt packages for aarch64-unknown-linux-gnu and s390x-unknown-linux-gnu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
         - build: x86_64-mingw
           os: windows-latest
           target: x86_64-pc-windows-gnu
+        - build: aarch64-linux
+          os: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+        - build: s390x-linux
+          os: ubuntu-latest
+          target: s390x-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,14 @@ jobs:
         with:
           name: bins-x86_64-linux
           path: dist
+      - uses: actions/download-artifact@v1
+        with:
+          name: bins-aarch64-linux
+          path: dist
+      - uses: actions/download-artifact@v1
+        with:
+          name: bins-s390x-linux
+          path: dist
 
       - name: Calculate tag name
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,4 +130,4 @@ jobs:
         working-directory: ./npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: for n in *; do (echo $n && cd $n && npm publish); done
+        run: for dir in *; do (echo $dir && cd $dir && npm publish); done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,3 +121,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.tagname.outputs.val }}
         continue-on-error: true
+      - name: Update npm packages to latest version
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        working-directory: ./npm/wizer
+        run: npm install && npm version "${{ steps.tagname.outputs.val }}"
+      - name: Publish npm packages
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        working-directory: ./npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: for n in *; do (echo $n && cd $n && npm publish); done

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ npm/wizer-darwin-arm64/
 npm/wizer-darwin-x64/
 npm/wizer-linux-x64/
 npm/wizer-win32-x64/
+npm/wizer-linux-s390x/
+npm/wizer-linux-arm64/

--- a/npm/wizer/wizer.js
+++ b/npm/wizer/wizer.js
@@ -6,7 +6,9 @@ const knownPackages = {
     "win32 x64 LE": "@bytecodealliance/wizer-win32-x64",
     "darwin arm64 LE": "@bytecodealliance/wizer-darwin-arm64",
     "darwin x64 LE": "@bytecodealliance/wizer-darwin-x64",
+    "linux arm64 LE": "@bytecodealliance/wizer-linux-arm64",
     "linux x64 LE": "@bytecodealliance/wizer-linux-x64",
+    "linux s390x BE": "@bytecodealliance/wizer-linux-s390x",
 };
 
 function pkgForCurrentPlatform() {


### PR DESCRIPTION
This brings in prebuilt packages for aarch64-unknown-linux-gnu and s390x-unknown-linux-gnu

This also adds an automated npm publishing step, this step would require an npm token be added into the GitHub Repositories secrets. If this is not wanted, please let me know and I can remove this step

Resolves https://github.com/bytecodealliance/wizer/issues/67