### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "wizer"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cap-std 0.24.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "wizer"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "cap-std 0.24.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wizer"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wizer"
-version = "2.0.1"
+version = "3.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wizer"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wizer"
-version = "2.0.0"
+version = "2.0.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/npm/wizer/package-lock.json
+++ b/npm/wizer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bytecodealliance/wizer",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/wizer",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "bin": {
         "wizer": "wizer.js"
@@ -21,10 +21,10 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@bytecodealliance/wizer-darwin-arm64": "2.0.1",
-        "@bytecodealliance/wizer-darwin-x64": "2.0.1",
-        "@bytecodealliance/wizer-linux-x64": "2.0.1",
-        "@bytecodealliance/wizer-win32-x64": "2.0.1"
+        "@bytecodealliance/wizer-darwin-arm64": "3.0.0",
+        "@bytecodealliance/wizer-darwin-x64": "3.0.0",
+        "@bytecodealliance/wizer-linux-x64": "3.0.0",
+        "@bytecodealliance/wizer-win32-x64": "3.0.0"
       }
     },
     "node_modules/base64-js": {

--- a/npm/wizer/package-lock.json
+++ b/npm/wizer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bytecodealliance/wizer",
-  "version": "1.6.1-beta.4",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/wizer",
-      "version": "1.6.1-beta.4",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "bin": {
         "wizer": "wizer.js"
@@ -21,10 +21,10 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@bytecodealliance/wizer-darwin-arm64": "1.6.1-beta.4",
-        "@bytecodealliance/wizer-darwin-x64": "1.6.1-beta.4",
-        "@bytecodealliance/wizer-linux-x64": "1.6.1-beta.4",
-        "@bytecodealliance/wizer-win32-x64": "1.6.1-beta.4"
+        "@bytecodealliance/wizer-darwin-arm64": "2.0.1",
+        "@bytecodealliance/wizer-darwin-x64": "2.0.1",
+        "@bytecodealliance/wizer-linux-x64": "2.0.1",
+        "@bytecodealliance/wizer-win32-x64": "2.0.1"
       }
     },
     "node_modules/base64-js": {

--- a/npm/wizer/package.json
+++ b/npm/wizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytecodealliance/wizer",
-  "version": "1.6.1-beta.4",
+  "version": "2.0.1",
   "description": "The WebAssembly Pre-Initializer",
   "type": "module",
   "scripts": {
@@ -20,10 +20,10 @@
     "wizer": "./wizer.js"
   },
   "optionalDependencies": {
-    "@bytecodealliance/wizer-darwin-arm64": "1.6.1-beta.4",
-    "@bytecodealliance/wizer-darwin-x64": "1.6.1-beta.4",
-    "@bytecodealliance/wizer-linux-x64": "1.6.1-beta.4",
-    "@bytecodealliance/wizer-win32-x64": "1.6.1-beta.4"
+    "@bytecodealliance/wizer-darwin-arm64": "2.0.1",
+    "@bytecodealliance/wizer-darwin-x64": "2.0.1",
+    "@bytecodealliance/wizer-linux-x64": "2.0.1",
+    "@bytecodealliance/wizer-win32-x64": "2.0.1"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/npm/wizer/package.json
+++ b/npm/wizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytecodealliance/wizer",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "The WebAssembly Pre-Initializer",
   "type": "module",
   "scripts": {
@@ -20,10 +20,10 @@
     "wizer": "./wizer.js"
   },
   "optionalDependencies": {
-    "@bytecodealliance/wizer-darwin-arm64": "2.0.1",
-    "@bytecodealliance/wizer-darwin-x64": "2.0.1",
-    "@bytecodealliance/wizer-linux-x64": "2.0.1",
-    "@bytecodealliance/wizer-win32-x64": "2.0.1"
+    "@bytecodealliance/wizer-darwin-arm64": "3.0.0",
+    "@bytecodealliance/wizer-darwin-x64": "3.0.0",
+    "@bytecodealliance/wizer-linux-x64": "3.0.0",
+    "@bytecodealliance/wizer-win32-x64": "3.0.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/npm/wizer/package.json
+++ b/npm/wizer/package.json
@@ -23,6 +23,8 @@
     "@bytecodealliance/wizer-darwin-arm64": "3.0.0",
     "@bytecodealliance/wizer-darwin-x64": "3.0.0",
     "@bytecodealliance/wizer-linux-x64": "3.0.0",
+    "@bytecodealliance/wizer-linux-arm64": "3.0.0",
+    "@bytecodealliance/wizer-linux-s390x": "3.0.0",
     "@bytecodealliance/wizer-win32-x64": "3.0.0"
   },
   "license": "Apache-2.0",

--- a/npm/wizer/update.js
+++ b/npm/wizer/update.js
@@ -33,6 +33,20 @@ let packages = {
         os: 'linux',
         cpu: 'x64',
     },
+    'wizer-linux-arm64': {
+        releaseAsset: `wizer-${tag}-arm64-linux.tar.xz`,
+        binaryAsset: 'wizer',
+        description : 'The Linux 64-bit binary for Wizer, the WebAssembly Pre-Initializer',
+        os: 'linux',
+        cpu: 'arm64',
+    },
+    'wizer-linux-s390x': {
+        releaseAsset: `wizer-${tag}-s390x-linux.tar.xz`,
+        binaryAsset: 'wizer',
+        description: 'The Linux S390X binary for Wizer, the WebAssembly Pre-Initializer',
+        os: 'linux',
+        cpu: 's390x',
+    },
     'wizer-win32-x64': {
         releaseAsset: `wizer-${tag}-x86_64-windows.zip`,
         binaryAsset: 'wizer.exe',


### PR DESCRIPTION
The changes included in 2.0.1 are:

-  Update wasmtime/wasm-tools dependencies ([#86](https://github.com/bytecodealliance/wizer/pull/86))

-  Add prebuilt packages for aarch64-unknown-linux-gnu and s390x-unknown-linux-gnu ([#87](https://github.com/bytecodealliance/wizer/pull/87))