### PR TITLE
Un-export `_initialize` even with keep-init 

### DIFF
--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -107,9 +107,9 @@ impl Wizer {
                 s if s.id == u8::from(SectionId::Export) => {
                     let mut exports = wasm_encoder::ExportSection::new();
                     for export in module.exports(cx) {
-                        if !self.keep_init_func.unwrap_or(DEFAULT_KEEP_INIT_FUNC)
-                            && (export.name == self.init_func
-                                || (has_wasi_initialize && export.name == "_initialize"))
+                        if (export.name == self.init_func
+                            && !self.keep_init_func.unwrap_or(DEFAULT_KEEP_INIT_FUNC))
+                            || (has_wasi_initialize && export.name == "_initialize")
                         {
                             continue;
                         }


### PR DESCRIPTION
Calling `_initialize` multiple times is undefined behavior and recent wasi-libc explicitly rejects it: https://github.com/WebAssembly/wasi-libc/commit/9bec2d3aff198770e98544cb6f13add60e1f5fe6

The original intention for `--init-keep-func` was to allow custom exported func (not `_initialize`) to be called by wizer multiple times, so this change doesn't break the original use case.