### PR TITLE
Fix the npm package to correctly use the two new prebuilt binaries for linux arm64 and s390x

### DIFF
--- a/npm/wizer/index.js
+++ b/npm/wizer/index.js
@@ -1,21 +1,4 @@
-import { endianness } from "node:os";
-import { platform, arch } from "node:process";
-
-const knownPackages = {
-  "win32 x64 LE": "@bytecodealliance/wizer-win32-x64",
-  "darwin arm64 LE": "@bytecodealliance/wizer-darwin-arm64",
-  "darwin x64 LE": "@bytecodealliance/wizer-darwin-x64",
-  "linux x64 LE": "@bytecodealliance/wizer-linux-x64",
-};
-
-function pkgForCurrentPlatform() {
-  let platformKey = `${platform} ${arch} ${endianness()}`;
-
-  if (platformKey in knownPackages) {
-    return knownPackages[platformKey];
-  }
-  throw new Error(`Unsupported platform: "${platformKey}". "@bytecodealliance/wizer does not have a precompiled binary for the platform/architecture you are using. You can open an issue on https://github.com/bytecodealliance/wizer/issues to request for your platform/architecture to be included."`);
-}
+import { pkgForCurrentPlatform } from "./package-helpers.js";
 
 const pkg = pkgForCurrentPlatform();
 

--- a/npm/wizer/package-helpers.js
+++ b/npm/wizer/package-helpers.js
@@ -1,0 +1,19 @@
+import { endianness } from "node:os";
+import { platform, arch } from "node:process";
+
+const knownPackages = {
+    "win32 x64 LE": "@bytecodealliance/wizer-win32-x64",
+    "darwin arm64 LE": "@bytecodealliance/wizer-darwin-arm64",
+    "darwin x64 LE": "@bytecodealliance/wizer-darwin-x64",
+    "linux arm64 LE": "@bytecodealliance/wizer-linux-arm64",
+    "linux s390x BE": "@bytecodealliance/wizer-linux-s390x",
+    "linux x64 LE": "@bytecodealliance/wizer-linux-x64",
+};
+
+export function pkgForCurrentPlatform() {
+    let platformKey = `${platform} ${arch} ${endianness()}`;
+    if (platformKey in knownPackages) {
+        return knownPackages[platformKey];
+    }
+    throw new Error(`Unsupported platform: "${platformKey}". "@bytecodealliance/wizer does not have a precompiled binary for the platform/architecture you are using. You can open an issue on https://github.com/bytecodealliance/wizer/issues to request for your platform/architecture to be included."`);
+}

--- a/npm/wizer/update.js
+++ b/npm/wizer/update.js
@@ -34,7 +34,7 @@ let packages = {
         cpu: 'x64',
     },
     'wizer-linux-arm64': {
-        releaseAsset: `wizer-${tag}-arm64-linux.tar.xz`,
+        releaseAsset: `wizer-${tag}-aarch64-linux.tar.xz`,
         binaryAsset: 'wizer',
         description : 'The Linux 64-bit binary for Wizer, the WebAssembly Pre-Initializer',
         os: 'linux',

--- a/npm/wizer/wizer.js
+++ b/npm/wizer/wizer.js
@@ -1,24 +1,7 @@
 #!/usr/bin/env node
-import { endianness } from "node:os";
-import { platform, arch } from "node:process";
 import { execFileSync } from "node:child_process";
-const knownPackages = {
-    "win32 x64 LE": "@bytecodealliance/wizer-win32-x64",
-    "darwin arm64 LE": "@bytecodealliance/wizer-darwin-arm64",
-    "darwin x64 LE": "@bytecodealliance/wizer-darwin-x64",
-    "linux arm64 LE": "@bytecodealliance/wizer-linux-arm64",
-    "linux x64 LE": "@bytecodealliance/wizer-linux-x64",
-    "linux s390x BE": "@bytecodealliance/wizer-linux-s390x",
-};
 
-function pkgForCurrentPlatform() {
-    let platformKey = `${platform} ${arch} ${endianness()}`;
-
-    if (platformKey in knownPackages) {
-        return knownPackages[platformKey];
-    }
-    throw new Error(`Unsupported platform: "${platformKey}". "@bytecodealliance/wizer does not have a precompiled binary for the platform/architecture you are using. You can open an issue on https://github.com/bytecodealliance/wizer/issues to request for your platform/architecture to be included."`);
-}
+import  { pkgForCurrentPlatform } from "./package-helpers.js";
 
 const pkg = pkgForCurrentPlatform();
 


### PR DESCRIPTION
The new linux arm64 binary was not being downloaded correctly as I was using the wrong filename when attempting to download from the github release assets, the filename contains aarch64 and not arm64.

I also forgot to update the definition within the main wizer npm package about what platforms are supported, this is due to it be duplicated across two files. To avoid this mistake in the future, I've refactored the code to not duplicate the definition anymore.

I think this should likely be a patch release, which I am happy to do when/if this pull-request lands on main