### PR TITLE
release: add npmrc to ensure publish permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,8 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         working-directory: ./npm/wizer
         run: npm install && npm version "${{ steps.tagname.outputs.val }}" --allow-same-version
+      - name: Setup npm auth
+        run: npm config set '//registry.npmjs.org/:_authToken'='$NODE_AUTH_TOKEN'
       - name: Publish npm packages
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         working-directory: ./npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
         working-directory: ./npm/wizer
         run: npm install && npm version "${{ steps.tagname.outputs.val }}" --allow-same-version
       - name: Setup npm auth
-        run: npm config set '//registry.npmjs.org/:_authToken'='$NODE_AUTH_TOKEN'
+        run: npm config --global set '//registry.npmjs.org/:_authToken'='$NODE_AUTH_TOKEN'
       - name: Publish npm packages
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         working-directory: ./npm

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION
This is required to ensure that `NPM_AUTH_TOKEN` attaches during the publish command.