### PR TITLE
release: fix version updating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Update npm packages to latest version
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         working-directory: ./npm/wizer
-        run: npm install && npm version "${{ steps.tagname.outputs.val }}" --allow-same-version
+        run: npm install && node update.js "${{ steps.tagname.outputs.val }}"
       - name: Setup npm auth
         run: sudo npm config --global set '//registry.npmjs.org/:_authToken'='${NODE_AUTH_TOKEN}'
       - name: Publish npm packages

--- a/npm/wizer/package.json
+++ b/npm/wizer/package.json
@@ -1,11 +1,9 @@
 {
   "name": "@bytecodealliance/wizer",
-  "version": "6.0.0",
+  "version": "VERSION",
   "description": "The WebAssembly Pre-Initializer",
+  "private": true,
   "type": "module",
-  "scripts": {
-    "version": "node ./update.js $npm_package_version"
-  },
   "devDependencies": {
     "decompress": "^4.2.1",
     "decompress-unzip": "^4.0.1",
@@ -20,12 +18,12 @@
     "wizer": "./wizer.js"
   },
   "optionalDependencies": {
-    "@bytecodealliance/wizer-darwin-arm64": "6.0.0",
-    "@bytecodealliance/wizer-darwin-x64": "6.0.0",
-    "@bytecodealliance/wizer-linux-x64": "6.0.0",
-    "@bytecodealliance/wizer-linux-arm64": "6.0.0",
-    "@bytecodealliance/wizer-linux-s390x": "6.0.0",
-    "@bytecodealliance/wizer-win32-x64": "6.0.0"
+    "@bytecodealliance/wizer-darwin-arm64": "VERSION",
+    "@bytecodealliance/wizer-darwin-x64": "VERSION",
+    "@bytecodealliance/wizer-linux-x64": "VERSION",
+    "@bytecodealliance/wizer-linux-arm64": "VERSION",
+    "@bytecodealliance/wizer-linux-s390x": "VERSION",
+    "@bytecodealliance/wizer-win32-x64": "VERSION"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/npm/wizer/update.js
+++ b/npm/wizer/update.js
@@ -2,14 +2,22 @@
 
 import { fileURLToPath } from 'node:url';
 import { dirname, join, parse } from 'node:path';
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
 import decompress from 'decompress';
 import decompressUnzip from 'decompress-unzip';
 import decompressTar from 'decompress-tar';
 import plzma from 'plzmasdk';
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const input = process.argv.slice(2).at(0);
-const tag = input ? `v${input}` : 'dev';
+const version = process.argv.slice(2).at(0).trim();
+const tag = version ? `v${version}` : 'dev';
+
+const pjson = JSON.parse(await readFile('package.json'));
+pjson.version = version;
+delete pjson.private;
+for (const dep of Object.keys(pjson.optionalDependencies)) {
+    pjson.optionalDependencies[dep] = version;
+}
+await writeFile('package.json', JSON.stringify(pjson, null, 2));
 
 let packages = {
     'wizer-darwin-arm64': {


### PR DESCRIPTION
Unfortunately we still aren't quite there.

The published package.json didn't automatically update the versions to reference the latest dependency versions (see optional dependencies in https://unpkg.com/@bytecodealliance/wizer@7.0.2/package.json).

We therefore need to update the versioning command to also update the versions in `optionalDependencies`, which this PR now does.