### PR TITLE
Fix Intel Mac CI builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           os: ubuntu-latest
         - build: x86_64-macos
           os: macos-latest
+          target: x86_64-apple-darwin
         - build: aarch64-macos
           os: macos-latest
           target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
           os: ubuntu-latest
         - build: x86_64-macos
           os: macos-latest
+          target: x86_64-apple-darwin
         - build: aarch64-macos
           os: macos-latest
           target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     # Assemble release artifats appropriate for this platform, then upload them
     # unconditionally to this workflow's files so we have a copy of them.
     - run: ./ci/build-tarballs.sh "${{ matrix.build }}" "${{ matrix.target }}"
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: bins-${{ matrix.build }}
         path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,31 +70,31 @@ jobs:
       # Download all the artifacts that we'll be publishing. Should keep an eye on
       # the `download-artifact` repository to see if we can ever get something
       # like "download all artifacts" or "download this list of artifacts"
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: bins-x86_64-macos
           path: dist
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: bins-aarch64-macos
           path: dist
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: bins-x86_64-windows
           path: dist
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: bins-x86_64-mingw
           path: dist
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: bins-x86_64-linux
           path: dist
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: bins-aarch64-linux
           path: dist
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
           name: bins-s390x-linux
           path: dist


### PR DESCRIPTION
We build both x86-64 and aarch64 ("Intel Mac" and "Apple Silicon Mac") binaries for wizer in CI on the `macos-latest` CI runner. Historically, this runner was an x86-64 machine, so while we could do a direct compile for x86-64 binaries, we added a target override for `aarch64-darwin` for the aarch64 builds to force a cross-compile.

When GitHub switched macOS CI runners to aarch64 (ARM64) machines somewhat recently, the `macos-latest` runner image began producing aarch64 binaries by default, and the target override for cross-compilation became meaningless (redundant). As a result, *both* of our x86-64 and aarch64 macOS binary artifacts contained aarch64 binaries. This is a problem for anyone running an Intel Mac.

This PR switches the CI config to specify a cross-compilation of x86-64 binaries, so each target builds its proper architecture.