### PR TITLE
add option for reference-types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,31 +760,31 @@ impl Wizer {
                                 anyhow::bail!("unsupported `data.drop` instruction")
                             }
                             wasmparser::Operator::TableSet { .. } => {
-                                anyhow::bail!("part of reference types")
-                            }
-                            wasmparser::Operator::RefNull { .. } => {
-                                anyhow::bail!("part of reference types")
-                            }
-                            wasmparser::Operator::RefIsNull => {
-                                anyhow::bail!("part of reference types")
-                            }
-                            wasmparser::Operator::TypedSelect { .. } => {
-                                anyhow::bail!("part of reference types")
-                            }
-                            wasmparser::Operator::RefFunc { .. } => {
-                                anyhow::bail!("part of reference types")
+                                anyhow::bail!("unsupported `table.set` instruction")
                             }
                             wasmparser::Operator::TableGet { .. } => {
-                                anyhow::bail!("part of reference types")
+                                anyhow::bail!("unsupported `table.get` instruction")
+                            }
+                            wasmparser::Operator::RefNull { .. } => {
+                                anyhow::bail!("unsupported `ref.null` instruction")
+                            }
+                            wasmparser::Operator::RefIsNull => {
+                                anyhow::bail!("unsupported `ref.is_null` instruction")
+                            }
+                            wasmparser::Operator::TypedSelect { .. } => {
+                                anyhow::bail!("unsupported typed `select` instruction")
+                            }
+                            wasmparser::Operator::RefFunc { .. } => {
+                                anyhow::bail!("unsupported `ref.func` instruction")
                             }
                             wasmparser::Operator::TableSize { .. } => {
-                                anyhow::bail!("part of reference types")
+                                anyhow::bail!("unsupported `table.size` instruction")
                             }
                             wasmparser::Operator::TableGrow { .. } => {
-                                anyhow::bail!("part of reference types")
+                                anyhow::bail!("unsupported `table.grow` instruction")
                             }
                             wasmparser::Operator::TableFill { .. } => {
-                                anyhow::bail!("part of reference types")
+                                anyhow::bail!("unsupported `table.fill` instruction")
                             }
                             _ => continue,
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,6 +754,30 @@ impl Wizer {
                             wasmparser::Operator::TableSet { .. } => {
                                 unreachable!("part of reference types")
                             }
+                            wasmparser::Operator::RefNull { .. } => {
+                                unreachable!("part of reference types")
+                            }
+                            wasmparser::Operator::RefIsNull => {
+                                unreachable!("part of reference types")
+                            }
+                            wasmparser::Operator::TypedSelect { .. } => {
+                                unreachable!("part of reference types")
+                            }
+                            wasmparser::Operator::RefFunc { .. } => {
+                                unreachable!("part of reference types")
+                            }
+                            wasmparser::Operator::TableGet { .. } => {
+                                unreachable!("part of reference types")
+                            }
+                            wasmparser::Operator::TableSize { .. } => {
+                                unreachable!("part of reference types")
+                            }
+                            wasmparser::Operator::TableGrow { .. } => {
+                                unreachable!("part of reference types")
+                            }
+                            wasmparser::Operator::TableFill { .. } => {
+                                unreachable!("part of reference types")
+                            }
                             _ => continue,
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ const DEFAULT_WASM_MULTI_VALUE: bool = true;
 const DEFAULT_WASM_MULTI_MEMORY: bool = true;
 const DEFAULT_WASM_BULK_MEMORY: bool = false;
 const DEFAULT_WASM_SIMD: bool = true;
+const DEFAULT_WASM_REFERENCE_TYPES: bool = false;
 
 /// The type of data that is stored in the `wasmtime::Store` during
 /// initialization.
@@ -249,6 +250,15 @@ pub struct Wizer {
     /// Enabled by default.
     #[cfg_attr(feature = "structopt", structopt(long, value_name = "true|false"))]
     wasm_simd: Option<bool>,
+
+    /// Enable or disable the Wasm reference-types proposal.
+    ///
+    /// Currently does not implement any reference-types specific code,
+    /// but enables initializing Modules that have reference-types enabled
+    ///
+    /// Disabled by default.
+    #[cfg_attr(feature = "structopt", structopt(long, value_name = "true|false"))]
+    wasm_reference_types: Option<bool>,
 }
 
 impl std::fmt::Debug for Wizer {
@@ -269,6 +279,7 @@ impl std::fmt::Debug for Wizer {
             wasm_multi_value,
             wasm_bulk_memory,
             wasm_simd,
+            wasm_reference_types,
         } = self;
         f.debug_struct("Wizer")
             .field("init_func", &init_func)
@@ -286,6 +297,7 @@ impl std::fmt::Debug for Wizer {
             .field("wasm_multi_value", &wasm_multi_value)
             .field("wasm_bulk_memory", &wasm_bulk_memory)
             .field("wasm_simd", &wasm_simd)
+            .field("wasm_reference_types", &wasm_reference_types)
             .finish()
     }
 }
@@ -350,6 +362,7 @@ impl Wizer {
             wasm_multi_value: None,
             wasm_bulk_memory: None,
             wasm_simd: None,
+            wasm_reference_types: None,
         }
     }
 
@@ -632,8 +645,14 @@ impl Wizer {
 
         config.wasm_simd(self.wasm_simd.unwrap_or(DEFAULT_WASM_SIMD));
 
+        // Note that reference_types are not actually supported,
+        // but many compilers now enable them by default
+        config.wasm_reference_types(
+            self.wasm_reference_types
+                .unwrap_or(DEFAULT_WASM_REFERENCE_TYPES),
+        );
+
         // Proposals that we should add support for.
-        config.wasm_reference_types(false);
         config.wasm_threads(false);
 
         Ok(config)
@@ -654,7 +673,9 @@ impl Wizer {
             multi_value: self.wasm_multi_value.unwrap_or(DEFAULT_WASM_MULTI_VALUE),
 
             // Proposals that we should add support for.
-            reference_types: false,
+            reference_types: self
+                .wasm_reference_types
+                .unwrap_or(DEFAULT_WASM_REFERENCE_TYPES),
             simd: self.wasm_simd.unwrap_or(DEFAULT_WASM_SIMD),
             threads: false,
             tail_call: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,31 +760,31 @@ impl Wizer {
                                 anyhow::bail!("unsupported `data.drop` instruction")
                             }
                             wasmparser::Operator::TableSet { .. } => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             wasmparser::Operator::RefNull { .. } => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             wasmparser::Operator::RefIsNull => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             wasmparser::Operator::TypedSelect { .. } => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             wasmparser::Operator::RefFunc { .. } => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             wasmparser::Operator::TableGet { .. } => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             wasmparser::Operator::TableSize { .. } => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             wasmparser::Operator::TableGrow { .. } => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             wasmparser::Operator::TableFill { .. } => {
-                                unreachable!("part of reference types")
+                                anyhow::bail!("part of reference types")
                             }
                             _ => continue,
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,8 +253,9 @@ pub struct Wizer {
 
     /// Enable or disable the Wasm reference-types proposal.
     ///
-    /// Currently does not implement any reference-types specific code,
-    /// but enables initializing Modules that have reference-types enabled
+    /// Currently does not implement snapshotting or the use of references,
+    /// but enables initializing Wasm modules that use encodings introduced
+    /// in the reference-types proposal.
     ///
     /// Disabled by default.
     #[cfg_attr(feature = "structopt", structopt(long, value_name = "true|false"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,6 +570,14 @@ impl Wizer {
         self
     }
 
+    /// Enable or disable the Wasm reference-types proposal.
+    ///
+    /// Defaults to `false`.
+    pub fn wasm_reference_types(&mut self, enable: bool) -> &mut Self {
+        self.wasm_reference_types = Some(enable);
+        self
+    }
+
     /// Initialize the given Wasm, snapshot it, and return the serialized
     /// snapshot as a new, pre-initialized Wasm module.
     pub fn run(&self, wasm: &[u8]) -> anyhow::Result<Vec<u8>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,6 +572,10 @@ impl Wizer {
 
     /// Enable or disable the Wasm reference-types proposal.
     ///
+    /// Currently does not implement snapshotting or the use of references,
+    /// but enables initializing Wasm modules that use encodings introduced
+    /// in the reference-types proposal.
+    ///
     /// Defaults to `false`.
     pub fn wasm_reference_types(&mut self, enable: bool) -> &mut Self {
         self.wasm_reference_types = Some(enable);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -298,8 +298,9 @@ fn reject_table_get_set_with_reference_types_enabled() -> Result<()> {
     assert!(result.is_err());
 
     let err = result.unwrap_err();
-    dbg!(&err);
-    assert!(err.to_string().contains("part of reference types"),);
+    assert!(err
+        .to_string()
+        .contains("unsupported `table.get` instruction"),);
 
     Ok(())
 }
@@ -328,8 +329,9 @@ fn reject_table_grow_with_reference_types_enabled() -> anyhow::Result<()> {
     assert!(result.is_err());
 
     let err = result.unwrap_err();
-    dbg!(&err);
-    assert!(err.to_string().contains("part of reference types"));
+    assert!(err
+        .to_string()
+        .contains("unsupported `ref.func` instruction"));
 
     Ok(())
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -341,15 +341,16 @@ fn indirect_call_with_reference_types() -> anyhow::Result<()> {
     let wat = r#"
       (module
         (type $sig (func (result i32)))
-        (table 1 funcref)
-        (elem (i32.const 0) $f)
+        (table 0 funcref)
+        (table $table1 1 funcref)
+        (elem (table $table1) (i32.const 0) func $f)
         (func $f (type $sig)
           i32.const 42
         )
         (func (export "wizer.initialize"))
         (func (export "run") (result i32)
           i32.const 0
-          call_indirect (type $sig)
+          call_indirect $table1 (type $sig)
         )
       )"#;
 


### PR DESCRIPTION
only enables the wasmtime feature, which allows initializing Modules that were compiled with newer llvm versions but don't actually use reference-types